### PR TITLE
feat: split layout for reviewing answers while editing outcome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ out/
 
 # Build
 dist/
+*.tsbuildinfo
 
 # IDE
 .vscode/

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,18 @@
 import type { NextConfig } from "next";
+import { resolve } from "path";
 
-const nextConfig: NextConfig = {};
+const __dirname = import.meta.dirname;
+
+const nextConfig: NextConfig = {
+  turbopack: {
+    resolveAlias: {
+      tailwindcss: resolve(__dirname, "node_modules/tailwindcss"),
+      "@tailwindcss/typography": resolve(
+        __dirname,
+        "node_modules/@tailwindcss/typography"
+      ),
+    },
+  },
+};
 
 export default nextConfig;

--- a/src/components/outcome-editor.tsx
+++ b/src/components/outcome-editor.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
-import { ReviewMaterials } from "./review-materials";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { ReviewMaterials, parseReviewBlock } from "./review-materials";
+import { Markdown } from "./markdown";
+import { ArtifactPreview } from "./artifact-preview";
 
 type OutputMode = "md-only" | "md-and-artifact";
 
@@ -116,6 +118,10 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
   const [rawContent, setRawContent] = useState("");
   const [nextOutputMode, setNextOutputMode] = useState<OutputMode>("md-only");
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [expandedView, setExpandedView] = useState<{
+    idx: number;
+    round: "r1" | "r2";
+  } | null>(null);
 
   useEffect(() => {
     fetch(`/api/sessions/${sessionId}/outcome`)
@@ -134,6 +140,27 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
       })
       .catch(() => {});
   }, [sessionId]);
+
+  useEffect(() => {
+    if (!expandedView) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setExpandedView(null);
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [expandedView]);
+
+  const submissions = useMemo(
+    () => (reviewBlock ? parseReviewBlock(reviewBlock) : []),
+    [reviewBlock],
+  );
+
+  const handleExpand = useCallback(
+    (idx: number, round: "r1" | "r2") => {
+      setExpandedView({ idx, round });
+    },
+    [],
+  );
 
   const save = useCallback(
     async (content: string) => {
@@ -186,6 +213,209 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
 
   if (!loaded) {
     return <div className="text-gray-500 text-sm">Loading outcome...</div>;
+  }
+
+  if (expandedView && submissions[expandedView.idx]) {
+    const sub = submissions[expandedView.idx];
+    const expandedContent =
+      expandedView.round === "r1" ? sub.round1 : sub.round2;
+
+    return (
+      <div className="flex gap-4" style={{ minHeight: "60vh" }}>
+        {/* Left: Answer content */}
+        <div className="flex-1 min-w-0 flex flex-col border border-gray-700 rounded-lg overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-2.5 bg-gray-800 border-b border-gray-700 shrink-0">
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={() => setExpandedView(null)}
+                className="text-gray-400 hover:text-gray-200 text-lg leading-none"
+                title="Close (ESC)"
+              >
+                &times;
+              </button>
+              <span className="font-medium text-sm text-gray-200">
+                {sub.name}
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <button
+                type="button"
+                onClick={() =>
+                  setExpandedView({ ...expandedView, round: "r1" })
+                }
+                className={`px-2 py-1 text-xs rounded transition-colors ${
+                  expandedView.round === "r1"
+                    ? "bg-blue-500/20 text-blue-300"
+                    : "text-gray-500 hover:text-gray-300"
+                }`}
+              >
+                R1
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  setExpandedView({ ...expandedView, round: "r2" })
+                }
+                className={`px-2 py-1 text-xs rounded transition-colors ${
+                  expandedView.round === "r2"
+                    ? "bg-blue-500/20 text-blue-300"
+                    : "text-gray-500 hover:text-gray-300"
+                }`}
+              >
+                R2
+              </button>
+              <span className="text-gray-700 mx-0.5">|</span>
+              <button
+                type="button"
+                onClick={() =>
+                  setExpandedView({
+                    ...expandedView,
+                    idx: expandedView.idx - 1,
+                  })
+                }
+                disabled={expandedView.idx === 0}
+                className="px-1.5 py-0.5 text-xs text-gray-400 hover:text-gray-200 disabled:text-gray-700 disabled:cursor-not-allowed transition-colors"
+              >
+                &#9664;
+              </button>
+              <span className="text-xs text-gray-500">
+                {expandedView.idx + 1}/{submissions.length}
+              </span>
+              <button
+                type="button"
+                onClick={() =>
+                  setExpandedView({
+                    ...expandedView,
+                    idx: expandedView.idx + 1,
+                  })
+                }
+                disabled={expandedView.idx === submissions.length - 1}
+                className="px-1.5 py-0.5 text-xs text-gray-400 hover:text-gray-200 disabled:text-gray-700 disabled:cursor-not-allowed transition-colors"
+              >
+                &#9654;
+              </button>
+            </div>
+          </div>
+          <div className="flex-1 p-5 overflow-y-auto">
+            {expandedContent ? (
+              <Markdown content={expandedContent} />
+            ) : (
+              <p className="text-gray-500 text-sm italic">No submission</p>
+            )}
+          </div>
+          {sub.hasArtifact && (
+            <div className="p-4 border-t border-gray-700 shrink-0">
+              <ArtifactPreview
+                sessionId={sessionId}
+                participant={sub.name}
+                turn={turn}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Right: Outcome sidebar */}
+        <div className="w-80 shrink-0 flex flex-col border border-gray-700 rounded-lg overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-2.5 bg-gray-800 border-b border-gray-700 shrink-0">
+            <span className="font-medium text-sm text-gray-200">
+              Turn {turn} — Outcome
+            </span>
+            {saving && (
+              <span className="text-xs text-gray-400">Saving...</span>
+            )}
+          </div>
+          <div className="flex-1 p-3 space-y-3 overflow-y-auto">
+            {/* Kind selector */}
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">Type</label>
+              <div className="flex flex-wrap gap-1">
+                {(Object.keys(KIND_LABELS) as OutcomeKind[]).map((k) => (
+                  <button
+                    key={k}
+                    type="button"
+                    onClick={() => updateKind(k)}
+                    className={`px-2 py-1 rounded text-xs border transition-colors ${
+                      kind === k
+                        ? "border-blue-500 bg-blue-500/20 text-blue-300"
+                        : "border-gray-700 bg-gray-900 text-gray-500 hover:border-gray-500"
+                    }`}
+                  >
+                    {k}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Decision */}
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">
+                Decision / Direction
+              </label>
+              <textarea
+                value={decision}
+                onChange={(e) => updateDecision(e.target.value)}
+                rows={8}
+                placeholder="What direction should the next turn take?"
+                className="w-full px-2 py-1.5 bg-gray-900 border border-gray-700 rounded text-sm resize-y focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+
+            {/* Notes */}
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">Notes</label>
+              <textarea
+                value={notes}
+                onChange={(e) => updateNotes(e.target.value)}
+                rows={4}
+                placeholder="Additional context..."
+                className="w-full px-2 py-1.5 bg-gray-900 border border-gray-700 rounded text-sm resize-y focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+
+            {/* Output format */}
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">
+                Next turn format
+              </label>
+              <div className="flex gap-1">
+                <button
+                  type="button"
+                  onClick={() => setNextOutputMode("md-only")}
+                  className={`flex-1 px-2 py-1 rounded text-xs border transition-colors ${
+                    nextOutputMode === "md-only"
+                      ? "border-blue-500 bg-blue-500/20 text-blue-300"
+                      : "border-gray-700 bg-gray-900 text-gray-500 hover:border-gray-500"
+                  }`}
+                >
+                  MD only
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setNextOutputMode("md-and-artifact")}
+                  className={`flex-1 px-2 py-1 rounded text-xs border transition-colors ${
+                    nextOutputMode === "md-and-artifact"
+                      ? "border-blue-500 bg-blue-500/20 text-blue-300"
+                      : "border-gray-700 bg-gray-900 text-gray-500 hover:border-gray-500"
+                  }`}
+                >
+                  MD + Artifact
+                </button>
+              </div>
+            </div>
+
+            {/* Advance button */}
+            <button
+              type="button"
+              onClick={handleAdvance}
+              className="w-full px-3 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded transition-colors"
+            >
+              Advance to Next Turn
+            </button>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -284,6 +514,7 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
               content={reviewBlock}
               sessionId={sessionId}
               turn={turn}
+              onExpand={handleExpand}
             />
           )}
 

--- a/src/components/review-materials.tsx
+++ b/src/components/review-materials.tsx
@@ -8,14 +8,14 @@ const REVIEW_BEGIN =
   "<!-- BEGIN REVIEW MATERIALS (stripped before next-turn delivery) -->";
 const REVIEW_END = "<!-- END REVIEW MATERIALS -->";
 
-interface Submission {
+export interface Submission {
   name: string;
   round1: string;
   round2: string;
   hasArtifact: boolean;
 }
 
-function parseReviewBlock(raw: string): Submission[] {
+export function parseReviewBlock(raw: string): Submission[] {
   let body = raw
     .replace(REVIEW_BEGIN, "")
     .replace(REVIEW_END, "")
@@ -123,11 +123,15 @@ function SubmissionCard({
   defaultOpen,
   sessionId,
   turn,
+  index,
+  onExpand,
 }: {
   submission: Submission;
   defaultOpen: boolean;
   sessionId?: string;
   turn?: number;
+  index?: number;
+  onExpand?: (idx: number, round: "r1" | "r2") => void;
 }) {
   const [activeTab, setActiveTab] = useState<"r1" | "r2">(
     submission.round2 ? "r2" : "r1",
@@ -182,7 +186,11 @@ function SubmissionCard({
               </button>
               <button
                 type="button"
-                onClick={() => setModal(true)}
+                onClick={() =>
+                  onExpand
+                    ? onExpand(index!, activeTab)
+                    : setModal(true)
+                }
                 className="px-3 py-1.5 text-xs text-gray-500 hover:text-gray-300 border-l border-gray-700 transition-colors"
               >
                 Expand
@@ -212,7 +220,7 @@ function SubmissionCard({
         )}
       </div>
 
-      {modal && content && (
+      {!onExpand && modal && content && (
         <ContentModal
           title={`${submission.name} — ${roundLabel}`}
           content={content}
@@ -230,6 +238,9 @@ function RoundViewCard({
   hasArtifact,
   sessionId,
   turn,
+  index,
+  round,
+  onExpand,
 }: {
   name: string;
   content: string;
@@ -237,6 +248,9 @@ function RoundViewCard({
   hasArtifact?: boolean;
   sessionId?: string;
   turn?: number;
+  index?: number;
+  round?: "r1" | "r2";
+  onExpand?: (idx: number, round: "r1" | "r2") => void;
 }) {
   const [modal, setModal] = useState(false);
 
@@ -247,7 +261,11 @@ function RoundViewCard({
           <span className="font-medium text-sm text-gray-200">{name}</span>
           <button
             type="button"
-            onClick={() => setModal(true)}
+            onClick={() =>
+              onExpand
+                ? onExpand(index!, round!)
+                : setModal(true)
+            }
             className="text-xs text-gray-500 hover:text-gray-300 opacity-0 group-hover:opacity-100 transition-opacity"
           >
             Expand
@@ -272,7 +290,7 @@ function RoundViewCard({
         )}
       </div>
 
-      {modal && content && (
+      {!onExpand && modal && content && (
         <ContentModal
           title={`${name} — ${roundLabel}`}
           content={content}
@@ -288,16 +306,18 @@ function RoundView({
   round,
   sessionId,
   turn,
+  onExpand,
 }: {
   submissions: Submission[];
   round: "r1" | "r2";
   sessionId?: string;
   turn?: number;
+  onExpand?: (idx: number, round: "r1" | "r2") => void;
 }) {
   const roundLabel = round === "r1" ? "Round 1" : "Round 2";
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-      {submissions.map((s) => (
+      {submissions.map((s, i) => (
         <RoundViewCard
           key={s.name}
           name={s.name}
@@ -306,6 +326,9 @@ function RoundView({
           hasArtifact={s.hasArtifact}
           sessionId={sessionId}
           turn={turn}
+          index={i}
+          round={round}
+          onExpand={onExpand}
         />
       ))}
     </div>
@@ -316,10 +339,12 @@ export function ReviewMaterials({
   content,
   sessionId,
   turn,
+  onExpand,
 }: {
   content: string;
   sessionId?: string;
   turn?: number;
+  onExpand?: (idx: number, round: "r1" | "r2") => void;
 }) {
   const [open, setOpen] = useState(true);
   const [viewMode, setViewMode] = useState<ViewMode>("participants");
@@ -383,6 +408,8 @@ export function ReviewMaterials({
                 defaultOpen={i === 0}
                 sessionId={sessionId}
                 turn={turn}
+                index={i}
+                onExpand={onExpand}
               />
             ))
           ) : (
@@ -417,6 +444,7 @@ export function ReviewMaterials({
                 round={roundTab}
                 sessionId={sessionId}
                 turn={turn}
+                onExpand={onExpand}
               />
             </>
           )}


### PR DESCRIPTION
## Summary
- Clicking **Expand** on a participant answer in the outcome editor now opens a side-by-side split layout instead of a full-screen modal
- Left panel shows the expanded answer with R1/R2 round switching and prev/next navigation between participants
- Right sidebar shows a compact outcome form (type, decision, notes, output format, advance button) with auto-save
- ESC key closes the split view and returns to the normal outcome editor
- Existing full-screen modal behavior preserved when `ReviewMaterials` is used outside of `OutcomeEditor`

## Test plan
- [ ] Enter outcome-pending phase, click Expand on a submission card → verify split layout appears
- [ ] Switch between R1/R2 tabs in the left panel
- [ ] Navigate between participants with ◀/▶ buttons
- [ ] Edit outcome fields in the right sidebar, verify auto-save works
- [ ] Press ESC to close the split view, verify normal form state is preserved
- [ ] Click Advance in the sidebar, verify it works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)