### PR TITLE
feat: adopt Catppuccin Mocha theme

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "smol-toml": "^1.6.1",
       },
       "devDependencies": {
+        "@catppuccin/tailwindcss": "^1.0.0",
         "@tailwindcss/postcss": "^4.2.4",
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
@@ -26,6 +27,8 @@
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "https://registry.npmmirror.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
+
+    "@catppuccin/tailwindcss": ["@catppuccin/tailwindcss@1.0.0", "https://registry.npmmirror.com/@catppuccin/tailwindcss/-/tailwindcss-1.0.0.tgz", {}, "sha512-l8pOlcYe2ncGd8a1gUmL5AHmKlxR2+CHuG5kt4Me6IZwzntW1DoLmj89BH+DcsPHBsdDGLrTSv35emlYyU3FeQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "https://registry.npmmirror.com/@emnapi/core/-/core-1.10.0.tgz", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "smol-toml": "^1.6.1"
   },
   "devDependencies": {
+    "@catppuccin/tailwindcss": "^1.0.0",
     "@tailwindcss/postcss": "^4.2.4",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,2 +1,3 @@
 @import "tailwindcss";
+@import "@catppuccin/tailwindcss/mocha.css";
 @plugin "@tailwindcss/typography";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,8 +12,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
-      <body className="bg-ctp-crust text-ctp-text min-h-screen antialiased">
+    <html lang="en" className="latte">
+      <body className="bg-ctp-base text-ctp-text min-h-screen antialiased">
         {children}
       </body>
     </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className="bg-gray-950 text-gray-100 min-h-screen antialiased">
+      <body className="bg-ctp-crust text-ctp-text min-h-screen antialiased">
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,21 +29,21 @@ export default function Home() {
         <h1 className="text-2xl font-bold">let-me-see-say</h1>
         <button
           onClick={() => setShowCreate(!showCreate)}
-          className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded-lg transition-colors"
+          className="px-4 py-2 bg-ctp-blue hover:bg-ctp-blue-400 text-ctp-crust text-sm rounded-lg transition-colors"
         >
           {showCreate ? "Cancel" : "New Session"}
         </button>
       </div>
 
       {showCreate && (
-        <div className="mb-8 p-6 rounded-lg border border-gray-800 bg-gray-900/50">
+        <div className="mb-8 p-6 rounded-lg border border-ctp-surface0 bg-ctp-mantle/50">
           <h2 className="text-lg font-semibold mb-4">New Session</h2>
           <CreateSessionForm />
         </div>
       )}
 
       {sessions.length === 0 ? (
-        <p className="text-gray-500">
+        <p className="text-ctp-overlay0">
           No sessions yet. Create one to get started.
         </p>
       ) : (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,7 +29,7 @@ export default function Home() {
         <h1 className="text-2xl font-bold">let-me-see-say</h1>
         <button
           onClick={() => setShowCreate(!showCreate)}
-          className="px-4 py-2 bg-ctp-blue hover:bg-ctp-blue-400 text-ctp-crust text-sm rounded-lg transition-colors"
+          className="px-4 py-2 bg-ctp-blue hover:bg-ctp-blue-400 text-ctp-base text-sm rounded-lg transition-colors"
         >
           {showCreate ? "Cancel" : "New Session"}
         </button>

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -103,7 +103,7 @@ export default function SessionPage({
   if (loading) {
     return (
       <main className="max-w-6xl mx-auto px-6 py-12">
-        <div className="text-gray-500">Loading session...</div>
+        <div className="text-ctp-overlay0">Loading session...</div>
       </main>
     );
   }
@@ -111,8 +111,8 @@ export default function SessionPage({
   if (error || !session) {
     return (
       <main className="max-w-6xl mx-auto px-6 py-12">
-        <div className="text-red-400">{error ?? "Session not found"}</div>
-        <Link href="/" className="text-blue-400 hover:underline text-sm mt-4 block">
+        <div className="text-ctp-red">{error ?? "Session not found"}</div>
+        <Link href="/" className="text-ctp-blue hover:underline text-sm mt-4 block">
           Back to dashboard
         </Link>
       </main>
@@ -136,11 +136,11 @@ export default function SessionPage({
         <div className="flex-1 min-w-0">
           <Link
             href="/"
-            className="text-xs text-gray-500 hover:text-gray-300 mb-1 block"
+            className="text-xs text-ctp-overlay0 hover:text-ctp-subtext1 mb-1 block"
           >
             &larr; Dashboard
           </Link>
-          <div className="text-xs text-gray-500 font-mono mt-1 mb-2">
+          <div className="text-xs text-ctp-overlay0 font-mono mt-1 mb-2">
             {session.sessionId}
           </div>
         </div>
@@ -149,14 +149,14 @@ export default function SessionPage({
             <>
               <button
                 onClick={handleCancel}
-                className="px-3 py-1.5 text-sm border border-red-800 text-red-400 hover:bg-red-900/30 rounded-md transition-colors"
+                className="px-3 py-1.5 text-sm border border-ctp-red/50 text-ctp-red hover:bg-ctp-red/15 rounded-md transition-colors"
               >
                 Cancel
               </button>
               {canResume && (
                 <button
                   onClick={handleResume}
-                  className="px-3 py-1.5 text-sm bg-green-700 hover:bg-green-600 text-white rounded-md transition-colors"
+                  className="px-3 py-1.5 text-sm bg-ctp-green/80 hover:bg-ctp-green text-ctp-crust rounded-md transition-colors"
                 >
                   Resume
                 </button>
@@ -164,7 +164,7 @@ export default function SessionPage({
               {isOutcomePending && (
                 <button
                   onClick={handleFinalize}
-                  className="px-3 py-1.5 text-sm border border-gray-600 text-gray-300 hover:bg-gray-800 rounded-md transition-colors"
+                  className="px-3 py-1.5 text-sm border border-ctp-surface2 text-ctp-subtext1 hover:bg-ctp-base rounded-md transition-colors"
                 >
                   Finalize
                 </button>
@@ -175,19 +175,19 @@ export default function SessionPage({
       </div>
 
       {/* Topic */}
-      <div className="p-4 rounded-lg border border-gray-800 bg-gray-900/50 max-h-64 overflow-y-auto">
+      <div className="p-4 rounded-lg border border-ctp-surface0 bg-ctp-mantle/50 max-h-64 overflow-y-auto">
         <Markdown content={session.topic} />
       </div>
 
       {/* Status bar */}
-      <div className="flex items-center gap-4 p-3 rounded-lg bg-gray-900/50 border border-gray-800">
+      <div className="flex items-center gap-4 p-3 rounded-lg bg-ctp-mantle/50 border border-ctp-surface0">
         <PhaseIndicator phase={currentPhase} />
-        <span className="text-sm text-gray-400">Turn {currentTurn}</span>
-        <span className="text-sm text-gray-500 flex-1">
+        <span className="text-sm text-ctp-subtext0">Turn {currentTurn}</span>
+        <span className="text-sm text-ctp-overlay0 flex-1">
           {PHASE_LABELS[currentPhase] ?? currentPhase}
         </span>
         {effectiveRunning && (
-          <span className="text-xs text-blue-400 animate-pulse">Running...</span>
+          <span className="text-xs text-ctp-blue animate-pulse">Running...</span>
         )}
       </div>
 
@@ -206,13 +206,13 @@ export default function SessionPage({
 
       {/* Outcome editor (when outcome-pending) */}
       {isOutcomePending && (
-        <div className="p-4 rounded-lg border border-gray-800 bg-gray-900/50">
+        <div className="p-4 rounded-lg border border-ctp-surface0 bg-ctp-mantle/50">
           <OutcomeEditor sessionId={id} onAdvance={handleAdvance} />
         </div>
       )}
 
       {/* Event log */}
-      <div className="p-4 rounded-lg border border-gray-800 bg-gray-900/50">
+      <div className="p-4 rounded-lg border border-ctp-surface0 bg-ctp-mantle/50">
         <h3 className="font-semibold text-sm mb-2">Event Log</h3>
         <EventLog events={events} />
       </div>

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -156,7 +156,7 @@ export default function SessionPage({
               {canResume && (
                 <button
                   onClick={handleResume}
-                  className="px-3 py-1.5 text-sm bg-ctp-green/80 hover:bg-ctp-green text-ctp-crust rounded-md transition-colors"
+                  className="px-3 py-1.5 text-sm bg-ctp-green/80 hover:bg-ctp-green text-ctp-base rounded-md transition-colors"
                 >
                   Resume
                 </button>
@@ -164,7 +164,7 @@ export default function SessionPage({
               {isOutcomePending && (
                 <button
                   onClick={handleFinalize}
-                  className="px-3 py-1.5 text-sm border border-ctp-surface2 text-ctp-subtext1 hover:bg-ctp-base rounded-md transition-colors"
+                  className="px-3 py-1.5 text-sm border border-ctp-surface2 text-ctp-subtext1 hover:bg-ctp-crust rounded-md transition-colors"
                 >
                   Finalize
                 </button>

--- a/src/components/artifact-preview.tsx
+++ b/src/components/artifact-preview.tsx
@@ -32,21 +32,21 @@ export function ArtifactPreview({
   const title = label ?? `${participant} — artifact`;
 
   return (
-    <div className="border border-gray-700 rounded-lg overflow-hidden">
-      <div className="flex items-center justify-between px-3 py-2 bg-gray-800 border-b border-gray-700">
-        <span className="text-xs font-medium text-gray-300">{title}</span>
+    <div className="border border-ctp-surface1 rounded-lg overflow-hidden">
+      <div className="flex items-center justify-between px-3 py-2 bg-ctp-base border-b border-ctp-surface1">
+        <span className="text-xs font-medium text-ctp-subtext1">{title}</span>
         <div className="flex gap-1">
           <button
             type="button"
             onClick={handleViewSource}
-            className="px-2 py-0.5 text-xs text-gray-400 hover:text-gray-200 border border-gray-700 rounded hover:bg-gray-800 transition-colors"
+            className="px-2 py-0.5 text-xs text-ctp-subtext0 hover:text-ctp-subtext1 border border-ctp-surface1 rounded hover:bg-ctp-base transition-colors"
           >
             {showSource ? "Preview" : "Source"}
           </button>
           <button
             type="button"
             onClick={() => setExpanded(!expanded)}
-            className="px-2 py-0.5 text-xs text-gray-400 hover:text-gray-200 border border-gray-700 rounded hover:bg-gray-800 transition-colors"
+            className="px-2 py-0.5 text-xs text-ctp-subtext0 hover:text-ctp-subtext1 border border-ctp-surface1 rounded hover:bg-ctp-base transition-colors"
           >
             {expanded ? "Collapse" : "Expand"}
           </button>
@@ -54,7 +54,7 @@ export function ArtifactPreview({
       </div>
 
       {showSource && source !== null ? (
-        <pre className={`p-3 bg-gray-900 text-xs text-gray-300 overflow-auto ${expanded ? "max-h-[70vh]" : "max-h-64"}`}>
+        <pre className={`p-3 bg-ctp-mantle text-xs text-ctp-subtext1 overflow-auto ${expanded ? "max-h-[70vh]" : "max-h-64"}`}>
           <code>{source}</code>
         </pre>
       ) : (

--- a/src/components/artifact-preview.tsx
+++ b/src/components/artifact-preview.tsx
@@ -33,20 +33,20 @@ export function ArtifactPreview({
 
   return (
     <div className="border border-ctp-surface1 rounded-lg overflow-hidden">
-      <div className="flex items-center justify-between px-3 py-2 bg-ctp-base border-b border-ctp-surface1">
+      <div className="flex items-center justify-between px-3 py-2 bg-ctp-crust border-b border-ctp-surface1">
         <span className="text-xs font-medium text-ctp-subtext1">{title}</span>
         <div className="flex gap-1">
           <button
             type="button"
             onClick={handleViewSource}
-            className="px-2 py-0.5 text-xs text-ctp-subtext0 hover:text-ctp-subtext1 border border-ctp-surface1 rounded hover:bg-ctp-base transition-colors"
+            className="px-2 py-0.5 text-xs text-ctp-subtext0 hover:text-ctp-subtext1 border border-ctp-surface1 rounded hover:bg-ctp-crust transition-colors"
           >
             {showSource ? "Preview" : "Source"}
           </button>
           <button
             type="button"
             onClick={() => setExpanded(!expanded)}
-            className="px-2 py-0.5 text-xs text-ctp-subtext0 hover:text-ctp-subtext1 border border-ctp-surface1 rounded hover:bg-ctp-base transition-colors"
+            className="px-2 py-0.5 text-xs text-ctp-subtext0 hover:text-ctp-subtext1 border border-ctp-surface1 rounded hover:bg-ctp-crust transition-colors"
           >
             {expanded ? "Collapse" : "Expand"}
           </button>

--- a/src/components/create-session-form.tsx
+++ b/src/components/create-session-form.tsx
@@ -152,7 +152,7 @@ export function CreateSessionForm() {
       <button
         type="submit"
         disabled={creating || !topic || !vaultPath || selected.size === 0}
-        className="px-4 py-2 bg-ctp-blue hover:bg-ctp-blue-400 disabled:bg-ctp-surface0 disabled:text-ctp-overlay0 text-ctp-crust text-sm rounded-lg transition-colors"
+        className="px-4 py-2 bg-ctp-blue hover:bg-ctp-blue-400 disabled:bg-ctp-surface0 disabled:text-ctp-overlay0 text-ctp-base text-sm rounded-lg transition-colors"
       >
         {creating ? "Creating..." : "Start Session"}
       </button>

--- a/src/components/create-session-form.tsx
+++ b/src/components/create-session-form.tsx
@@ -73,28 +73,28 @@ export function CreateSessionForm() {
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div>
-        <label className="block text-sm text-gray-400 mb-1">Topic</label>
+        <label className="block text-sm text-ctp-subtext0 mb-1">Topic</label>
         <textarea
           value={topic}
           onChange={(e) => setTopic(e.target.value)}
           placeholder="What should we brainstorm about?"
           rows={4}
-          className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded-lg text-sm resize-y focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="w-full px-3 py-2 bg-ctp-mantle border border-ctp-surface1 rounded-lg text-sm resize-y focus:outline-none focus:ring-2 focus:ring-ctp-blue"
           required
         />
       </div>
       <div>
-        <label className="block text-sm text-gray-400 mb-1">
+        <label className="block text-sm text-ctp-subtext0 mb-1">
           Vault Path
         </label>
         <DirPicker value={vaultPath} onChange={setVaultPath} />
       </div>
       <div>
-        <label className="block text-sm text-gray-400 mb-2">
+        <label className="block text-sm text-ctp-subtext0 mb-2">
           Participants
         </label>
         {Object.keys(profiles).length === 0 ? (
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-ctp-overlay0">
             No profiles found. Make sure agents.toml exists.
           </p>
         ) : (
@@ -106,8 +106,8 @@ export function CreateSessionForm() {
                 onClick={() => toggleProfile(name)}
                 className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${
                   selected.has(name)
-                    ? "border-blue-500 bg-blue-500/20 text-blue-300"
-                    : "border-gray-700 bg-gray-900 text-gray-400 hover:border-gray-500"
+                    ? "border-ctp-blue bg-ctp-blue/20 text-ctp-blue"
+                    : "border-ctp-surface1 bg-ctp-mantle text-ctp-subtext0 hover:border-ctp-overlay0"
                 }`}
               >
                 {name}
@@ -118,7 +118,7 @@ export function CreateSessionForm() {
         )}
       </div>
       <div>
-        <label className="block text-sm text-gray-400 mb-2">
+        <label className="block text-sm text-ctp-subtext0 mb-2">
           Output Format
         </label>
         <div className="flex gap-2">
@@ -127,8 +127,8 @@ export function CreateSessionForm() {
             onClick={() => setOutputMode("md-only")}
             className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${
               outputMode === "md-only"
-                ? "border-blue-500 bg-blue-500/20 text-blue-300"
-                : "border-gray-700 bg-gray-900 text-gray-400 hover:border-gray-500"
+                ? "border-ctp-blue bg-ctp-blue/20 text-ctp-blue"
+                : "border-ctp-surface1 bg-ctp-mantle text-ctp-subtext0 hover:border-ctp-overlay0"
             }`}
           >
             Markdown only
@@ -138,8 +138,8 @@ export function CreateSessionForm() {
             onClick={() => setOutputMode("md-and-artifact")}
             className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${
               outputMode === "md-and-artifact"
-                ? "border-blue-500 bg-blue-500/20 text-blue-300"
-                : "border-gray-700 bg-gray-900 text-gray-400 hover:border-gray-500"
+                ? "border-ctp-blue bg-ctp-blue/20 text-ctp-blue"
+                : "border-ctp-surface1 bg-ctp-mantle text-ctp-subtext0 hover:border-ctp-overlay0"
             }`}
           >
             Markdown + HTML artifact
@@ -147,12 +147,12 @@ export function CreateSessionForm() {
         </div>
       </div>
       {error && (
-        <div className="text-red-400 text-sm">{error}</div>
+        <div className="text-ctp-red text-sm">{error}</div>
       )}
       <button
         type="submit"
         disabled={creating || !topic || !vaultPath || selected.size === 0}
-        className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 text-white text-sm rounded-lg transition-colors"
+        className="px-4 py-2 bg-ctp-blue hover:bg-ctp-blue-400 disabled:bg-ctp-surface0 disabled:text-ctp-overlay0 text-ctp-crust text-sm rounded-lg transition-colors"
       >
         {creating ? "Creating..." : "Start Session"}
       </button>

--- a/src/components/dir-picker.tsx
+++ b/src/components/dir-picker.tsx
@@ -63,7 +63,7 @@ export function DirPicker({ value, onChange }: Props) {
         <button
           type="button"
           onClick={() => setOpen(!open)}
-          className="px-3 py-2 bg-ctp-base border border-ctp-surface1 rounded-lg text-sm text-ctp-subtext1 hover:bg-ctp-surface0 transition-colors shrink-0"
+          className="px-3 py-2 bg-ctp-crust border border-ctp-surface1 rounded-lg text-sm text-ctp-subtext1 hover:bg-ctp-surface0 transition-colors shrink-0"
         >
           Browse
         </button>
@@ -72,14 +72,14 @@ export function DirPicker({ value, onChange }: Props) {
       {open && (
         <div className="mt-2 border border-ctp-surface1 rounded-lg bg-ctp-mantle overflow-hidden">
           {/* Current path + select */}
-          <div className="flex items-center justify-between px-3 py-2 bg-ctp-base border-b border-ctp-surface1">
+          <div className="flex items-center justify-between px-3 py-2 bg-ctp-crust border-b border-ctp-surface1">
             <span className="text-xs font-mono text-ctp-subtext1 truncate flex-1">
               {current}
             </span>
             <button
               type="button"
               onClick={select}
-              className="ml-2 px-3 py-1 bg-ctp-blue hover:bg-ctp-blue-400 text-ctp-crust text-xs rounded transition-colors shrink-0"
+              className="ml-2 px-3 py-1 bg-ctp-blue hover:bg-ctp-blue-400 text-ctp-base text-xs rounded transition-colors shrink-0"
             >
               Select
             </button>
@@ -92,7 +92,7 @@ export function DirPicker({ value, onChange }: Props) {
               <button
                 type="button"
                 onClick={() => browse(parent)}
-                className="w-full text-left px-3 py-1.5 text-sm hover:bg-ctp-base transition-colors text-ctp-subtext0"
+                className="w-full text-left px-3 py-1.5 text-sm hover:bg-ctp-crust transition-colors text-ctp-subtext0"
               >
                 ..
               </button>
@@ -110,7 +110,7 @@ export function DirPicker({ value, onChange }: Props) {
                   key={entry.path}
                   type="button"
                   onClick={() => browse(entry.path)}
-                  className="w-full text-left px-3 py-1.5 text-sm hover:bg-ctp-base transition-colors text-ctp-subtext1"
+                  className="w-full text-left px-3 py-1.5 text-sm hover:bg-ctp-crust transition-colors text-ctp-subtext1"
                 >
                   {entry.name}/
                 </button>

--- a/src/components/dir-picker.tsx
+++ b/src/components/dir-picker.tsx
@@ -58,28 +58,28 @@ export function DirPicker({ value, onChange }: Props) {
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder="~/Obsidian/MyVault"
-          className="flex-1 px-3 py-2 bg-gray-900 border border-gray-700 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="flex-1 px-3 py-2 bg-ctp-mantle border border-ctp-surface1 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-ctp-blue"
         />
         <button
           type="button"
           onClick={() => setOpen(!open)}
-          className="px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm text-gray-300 hover:bg-gray-700 transition-colors shrink-0"
+          className="px-3 py-2 bg-ctp-base border border-ctp-surface1 rounded-lg text-sm text-ctp-subtext1 hover:bg-ctp-surface0 transition-colors shrink-0"
         >
           Browse
         </button>
       </div>
 
       {open && (
-        <div className="mt-2 border border-gray-700 rounded-lg bg-gray-900 overflow-hidden">
+        <div className="mt-2 border border-ctp-surface1 rounded-lg bg-ctp-mantle overflow-hidden">
           {/* Current path + select */}
-          <div className="flex items-center justify-between px-3 py-2 bg-gray-800 border-b border-gray-700">
-            <span className="text-xs font-mono text-gray-300 truncate flex-1">
+          <div className="flex items-center justify-between px-3 py-2 bg-ctp-base border-b border-ctp-surface1">
+            <span className="text-xs font-mono text-ctp-subtext1 truncate flex-1">
               {current}
             </span>
             <button
               type="button"
               onClick={select}
-              className="ml-2 px-3 py-1 bg-blue-600 hover:bg-blue-500 text-white text-xs rounded transition-colors shrink-0"
+              className="ml-2 px-3 py-1 bg-ctp-blue hover:bg-ctp-blue-400 text-ctp-crust text-xs rounded transition-colors shrink-0"
             >
               Select
             </button>
@@ -92,16 +92,16 @@ export function DirPicker({ value, onChange }: Props) {
               <button
                 type="button"
                 onClick={() => browse(parent)}
-                className="w-full text-left px-3 py-1.5 text-sm hover:bg-gray-800 transition-colors text-gray-400"
+                className="w-full text-left px-3 py-1.5 text-sm hover:bg-ctp-base transition-colors text-ctp-subtext0"
               >
                 ..
               </button>
             )}
 
             {loading ? (
-              <div className="px-3 py-2 text-xs text-gray-500">Loading...</div>
+              <div className="px-3 py-2 text-xs text-ctp-overlay0">Loading...</div>
             ) : entries.length === 0 ? (
-              <div className="px-3 py-2 text-xs text-gray-500">
+              <div className="px-3 py-2 text-xs text-ctp-overlay0">
                 No subdirectories
               </div>
             ) : (
@@ -110,7 +110,7 @@ export function DirPicker({ value, onChange }: Props) {
                   key={entry.path}
                   type="button"
                   onClick={() => browse(entry.path)}
-                  className="w-full text-left px-3 py-1.5 text-sm hover:bg-gray-800 transition-colors text-gray-300"
+                  className="w-full text-left px-3 py-1.5 text-sm hover:bg-ctp-base transition-colors text-ctp-subtext1"
                 >
                   {entry.name}/
                 </button>

--- a/src/components/event-log.tsx
+++ b/src/components/event-log.tsx
@@ -32,7 +32,7 @@ export function EventLog({ events }: { events: SessionEvent[] }) {
 
   if (filtered.length === 0) {
     return (
-      <div className="text-gray-500 text-sm">No events yet.</div>
+      <div className="text-ctp-overlay0 text-sm">No events yet.</div>
     );
   }
 
@@ -40,14 +40,14 @@ export function EventLog({ events }: { events: SessionEvent[] }) {
     <div className="max-h-48 overflow-y-auto space-y-0.5 font-mono text-xs">
       {filtered.map((event, i) => (
         <div key={i} className="flex gap-2">
-          <span className="text-gray-500 shrink-0">
+          <span className="text-ctp-overlay0 shrink-0">
             {formatTime(event.timestamp)}
           </span>
           <span
             className={
               event.type === "session:error"
-                ? "text-red-400"
-                : "text-gray-300"
+                ? "text-ctp-red"
+                : "text-ctp-subtext1"
             }
           >
             {eventMessage(event)}

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -12,11 +12,11 @@ export function Markdown({
   return (
     <div
       className={`prose prose-invert prose-sm max-w-none
-        prose-headings:text-gray-200 prose-p:text-gray-300
-        prose-a:text-blue-400 prose-strong:text-gray-200
-        prose-li:text-gray-300 prose-code:text-blue-300
-        prose-code:bg-gray-800 prose-code:px-1 prose-code:py-0.5 prose-code:rounded
-        prose-pre:bg-gray-900 prose-pre:border prose-pre:border-gray-700
+        prose-headings:text-ctp-subtext1 prose-p:text-ctp-subtext1
+        prose-a:text-ctp-blue prose-strong:text-ctp-subtext1
+        prose-li:text-ctp-subtext1 prose-code:text-ctp-blue
+        prose-code:bg-ctp-base prose-code:px-1 prose-code:py-0.5 prose-code:rounded
+        prose-pre:bg-ctp-mantle prose-pre:border prose-pre:border-ctp-surface1
         ${className ?? ""}`}
     >
       <ReactMarkdown>{content}</ReactMarkdown>

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -11,11 +11,11 @@ export function Markdown({
 }) {
   return (
     <div
-      className={`prose prose-invert prose-sm max-w-none
+      className={`prose prose-sm max-w-none
         prose-headings:text-ctp-subtext1 prose-p:text-ctp-subtext1
         prose-a:text-ctp-blue prose-strong:text-ctp-subtext1
         prose-li:text-ctp-subtext1 prose-code:text-ctp-blue
-        prose-code:bg-ctp-base prose-code:px-1 prose-code:py-0.5 prose-code:rounded
+        prose-code:bg-ctp-crust prose-code:px-1 prose-code:py-0.5 prose-code:rounded
         prose-pre:bg-ctp-mantle prose-pre:border prose-pre:border-ctp-surface1
         ${className ?? ""}`}
     >

--- a/src/components/outcome-editor.tsx
+++ b/src/components/outcome-editor.tsx
@@ -212,7 +212,7 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
   };
 
   if (!loaded) {
-    return <div className="text-gray-500 text-sm">Loading outcome...</div>;
+    return <div className="text-ctp-overlay0 text-sm">Loading outcome...</div>;
   }
 
   if (expandedView && submissions[expandedView.idx]) {
@@ -223,18 +223,18 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
     return (
       <div className="flex gap-4" style={{ minHeight: "60vh" }}>
         {/* Left: Answer content */}
-        <div className="flex-1 min-w-0 flex flex-col border border-gray-700 rounded-lg overflow-hidden">
-          <div className="flex items-center justify-between px-4 py-2.5 bg-gray-800 border-b border-gray-700 shrink-0">
+        <div className="flex-1 min-w-0 flex flex-col border border-ctp-surface1 rounded-lg overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-2.5 bg-ctp-base border-b border-ctp-surface1 shrink-0">
             <div className="flex items-center gap-3">
               <button
                 type="button"
                 onClick={() => setExpandedView(null)}
-                className="text-gray-400 hover:text-gray-200 text-lg leading-none"
+                className="text-ctp-subtext0 hover:text-ctp-subtext1 text-lg leading-none"
                 title="Close (ESC)"
               >
                 &times;
               </button>
-              <span className="font-medium text-sm text-gray-200">
+              <span className="font-medium text-sm text-ctp-subtext1">
                 {sub.name}
               </span>
             </div>
@@ -246,8 +246,8 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
                 }
                 className={`px-2 py-1 text-xs rounded transition-colors ${
                   expandedView.round === "r1"
-                    ? "bg-blue-500/20 text-blue-300"
-                    : "text-gray-500 hover:text-gray-300"
+                    ? "bg-ctp-blue/20 text-ctp-blue"
+                    : "text-ctp-overlay0 hover:text-ctp-subtext1"
                 }`}
               >
                 R1
@@ -259,13 +259,13 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
                 }
                 className={`px-2 py-1 text-xs rounded transition-colors ${
                   expandedView.round === "r2"
-                    ? "bg-blue-500/20 text-blue-300"
-                    : "text-gray-500 hover:text-gray-300"
+                    ? "bg-ctp-blue/20 text-ctp-blue"
+                    : "text-ctp-overlay0 hover:text-ctp-subtext1"
                 }`}
               >
                 R2
               </button>
-              <span className="text-gray-700 mx-0.5">|</span>
+              <span className="text-ctp-surface2 mx-0.5">|</span>
               <button
                 type="button"
                 onClick={() =>
@@ -275,11 +275,11 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
                   })
                 }
                 disabled={expandedView.idx === 0}
-                className="px-1.5 py-0.5 text-xs text-gray-400 hover:text-gray-200 disabled:text-gray-700 disabled:cursor-not-allowed transition-colors"
+                className="px-1.5 py-0.5 text-xs text-ctp-subtext0 hover:text-ctp-subtext1 disabled:text-ctp-surface2 disabled:cursor-not-allowed transition-colors"
               >
                 &#9664;
               </button>
-              <span className="text-xs text-gray-500">
+              <span className="text-xs text-ctp-overlay0">
                 {expandedView.idx + 1}/{submissions.length}
               </span>
               <button
@@ -291,7 +291,7 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
                   })
                 }
                 disabled={expandedView.idx === submissions.length - 1}
-                className="px-1.5 py-0.5 text-xs text-gray-400 hover:text-gray-200 disabled:text-gray-700 disabled:cursor-not-allowed transition-colors"
+                className="px-1.5 py-0.5 text-xs text-ctp-subtext0 hover:text-ctp-subtext1 disabled:text-ctp-surface2 disabled:cursor-not-allowed transition-colors"
               >
                 &#9654;
               </button>
@@ -301,11 +301,11 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
             {expandedContent ? (
               <Markdown content={expandedContent} />
             ) : (
-              <p className="text-gray-500 text-sm italic">No submission</p>
+              <p className="text-ctp-overlay0 text-sm italic">No submission</p>
             )}
           </div>
           {sub.hasArtifact && (
-            <div className="p-4 border-t border-gray-700 shrink-0">
+            <div className="p-4 border-t border-ctp-surface1 shrink-0">
               <ArtifactPreview
                 sessionId={sessionId}
                 participant={sub.name}
@@ -316,19 +316,19 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
         </div>
 
         {/* Right: Outcome sidebar */}
-        <div className="w-80 shrink-0 flex flex-col border border-gray-700 rounded-lg overflow-hidden">
-          <div className="flex items-center justify-between px-4 py-2.5 bg-gray-800 border-b border-gray-700 shrink-0">
-            <span className="font-medium text-sm text-gray-200">
+        <div className="w-80 shrink-0 flex flex-col border border-ctp-surface1 rounded-lg overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-2.5 bg-ctp-base border-b border-ctp-surface1 shrink-0">
+            <span className="font-medium text-sm text-ctp-subtext1">
               Turn {turn} — Outcome
             </span>
             {saving && (
-              <span className="text-xs text-gray-400">Saving...</span>
+              <span className="text-xs text-ctp-subtext0">Saving...</span>
             )}
           </div>
           <div className="flex-1 p-3 space-y-3 overflow-y-auto">
             {/* Kind selector */}
             <div>
-              <label className="block text-xs text-gray-500 mb-1">Type</label>
+              <label className="block text-xs text-ctp-overlay0 mb-1">Type</label>
               <div className="flex flex-wrap gap-1">
                 {(Object.keys(KIND_LABELS) as OutcomeKind[]).map((k) => (
                   <button
@@ -337,8 +337,8 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
                     onClick={() => updateKind(k)}
                     className={`px-2 py-1 rounded text-xs border transition-colors ${
                       kind === k
-                        ? "border-blue-500 bg-blue-500/20 text-blue-300"
-                        : "border-gray-700 bg-gray-900 text-gray-500 hover:border-gray-500"
+                        ? "border-ctp-blue bg-ctp-blue/20 text-ctp-blue"
+                        : "border-ctp-surface1 bg-ctp-mantle text-ctp-overlay0 hover:border-ctp-overlay0"
                     }`}
                   >
                     {k}
@@ -349,7 +349,7 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
 
             {/* Decision */}
             <div>
-              <label className="block text-xs text-gray-500 mb-1">
+              <label className="block text-xs text-ctp-overlay0 mb-1">
                 Decision / Direction
               </label>
               <textarea
@@ -357,25 +357,25 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
                 onChange={(e) => updateDecision(e.target.value)}
                 rows={8}
                 placeholder="What direction should the next turn take?"
-                className="w-full px-2 py-1.5 bg-gray-900 border border-gray-700 rounded text-sm resize-y focus:outline-none focus:ring-1 focus:ring-blue-500"
+                className="w-full px-2 py-1.5 bg-ctp-mantle border border-ctp-surface1 rounded text-sm resize-y focus:outline-none focus:ring-1 focus:ring-ctp-blue"
               />
             </div>
 
             {/* Notes */}
             <div>
-              <label className="block text-xs text-gray-500 mb-1">Notes</label>
+              <label className="block text-xs text-ctp-overlay0 mb-1">Notes</label>
               <textarea
                 value={notes}
                 onChange={(e) => updateNotes(e.target.value)}
                 rows={4}
                 placeholder="Additional context..."
-                className="w-full px-2 py-1.5 bg-gray-900 border border-gray-700 rounded text-sm resize-y focus:outline-none focus:ring-1 focus:ring-blue-500"
+                className="w-full px-2 py-1.5 bg-ctp-mantle border border-ctp-surface1 rounded text-sm resize-y focus:outline-none focus:ring-1 focus:ring-ctp-blue"
               />
             </div>
 
             {/* Output format */}
             <div>
-              <label className="block text-xs text-gray-500 mb-1">
+              <label className="block text-xs text-ctp-overlay0 mb-1">
                 Next turn format
               </label>
               <div className="flex gap-1">
@@ -384,8 +384,8 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
                   onClick={() => setNextOutputMode("md-only")}
                   className={`flex-1 px-2 py-1 rounded text-xs border transition-colors ${
                     nextOutputMode === "md-only"
-                      ? "border-blue-500 bg-blue-500/20 text-blue-300"
-                      : "border-gray-700 bg-gray-900 text-gray-500 hover:border-gray-500"
+                      ? "border-ctp-blue bg-ctp-blue/20 text-ctp-blue"
+                      : "border-ctp-surface1 bg-ctp-mantle text-ctp-overlay0 hover:border-ctp-overlay0"
                   }`}
                 >
                   MD only
@@ -395,8 +395,8 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
                   onClick={() => setNextOutputMode("md-and-artifact")}
                   className={`flex-1 px-2 py-1 rounded text-xs border transition-colors ${
                     nextOutputMode === "md-and-artifact"
-                      ? "border-blue-500 bg-blue-500/20 text-blue-300"
-                      : "border-gray-700 bg-gray-900 text-gray-500 hover:border-gray-500"
+                      ? "border-ctp-blue bg-ctp-blue/20 text-ctp-blue"
+                      : "border-ctp-surface1 bg-ctp-mantle text-ctp-overlay0 hover:border-ctp-overlay0"
                   }`}
                 >
                   MD + Artifact
@@ -408,7 +408,7 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
             <button
               type="button"
               onClick={handleAdvance}
-              className="w-full px-3 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded transition-colors"
+              className="w-full px-3 py-2 bg-ctp-blue hover:bg-ctp-blue-400 text-ctp-crust text-sm rounded transition-colors"
             >
               Advance to Next Turn
             </button>
@@ -425,18 +425,18 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
         <h3 className="font-semibold text-lg">Turn {turn} — Outcome</h3>
         <div className="flex items-center gap-3">
           {saving && (
-            <span className="text-xs text-gray-400">Saving...</span>
+            <span className="text-xs text-ctp-subtext0">Saving...</span>
           )}
           <button
             type="button"
             onClick={() => setShowRaw(!showRaw)}
-            className="px-3 py-1.5 text-xs border border-gray-700 text-gray-400 hover:text-gray-200 rounded-md transition-colors"
+            className="px-3 py-1.5 text-xs border border-ctp-surface1 text-ctp-subtext0 hover:text-ctp-subtext1 rounded-md transition-colors"
           >
             {showRaw ? "Form" : "Raw"}
           </button>
           <button
             onClick={handleAdvance}
-            className="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded-md transition-colors"
+            className="px-4 py-1.5 bg-ctp-blue hover:bg-ctp-blue-400 text-ctp-crust text-sm rounded-md transition-colors"
           >
             Advance to Next Turn
           </button>
@@ -454,14 +454,14 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
               1000,
             );
           }}
-          className="w-full h-96 bg-gray-900 border border-gray-700 rounded-lg p-4 font-mono text-sm text-gray-200 resize-y focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="w-full h-96 bg-ctp-mantle border border-ctp-surface1 rounded-lg p-4 font-mono text-sm text-ctp-subtext1 resize-y focus:outline-none focus:ring-2 focus:ring-ctp-blue"
           spellCheck={false}
         />
       ) : (
         <div className="space-y-4">
           {/* Kind selector */}
           <div>
-            <label className="block text-sm text-gray-400 mb-2">
+            <label className="block text-sm text-ctp-subtext0 mb-2">
               Outcome Type
             </label>
             <div className="flex flex-wrap gap-2">
@@ -472,8 +472,8 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
                   onClick={() => updateKind(k)}
                   className={`px-3 py-2 rounded-lg text-sm border transition-colors text-left ${
                     kind === k
-                      ? "border-blue-500 bg-blue-500/20 text-blue-300"
-                      : "border-gray-700 bg-gray-900 text-gray-400 hover:border-gray-500"
+                      ? "border-ctp-blue bg-ctp-blue/20 text-ctp-blue"
+                      : "border-ctp-surface1 bg-ctp-mantle text-ctp-subtext0 hover:border-ctp-overlay0"
                   }`}
                 >
                   {KIND_LABELS[k]}
@@ -484,7 +484,7 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
 
           {/* Decision / Direction */}
           <div>
-            <label className="block text-sm text-gray-400 mb-1">
+            <label className="block text-sm text-ctp-subtext0 mb-1">
               Decision / Direction
             </label>
             <textarea
@@ -492,19 +492,19 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
               onChange={(e) => updateDecision(e.target.value)}
               rows={6}
               placeholder="What direction should the next turn take? What was decided?"
-              className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded-lg text-sm resize-y focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full px-3 py-2 bg-ctp-mantle border border-ctp-surface1 rounded-lg text-sm resize-y focus:outline-none focus:ring-2 focus:ring-ctp-blue"
             />
           </div>
 
           {/* Notes */}
           <div>
-            <label className="block text-sm text-gray-400 mb-1">Notes</label>
+            <label className="block text-sm text-ctp-subtext0 mb-1">Notes</label>
             <textarea
               value={notes}
               onChange={(e) => updateNotes(e.target.value)}
               rows={3}
               placeholder="Additional context, caveats, or points to carry forward..."
-              className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded-lg text-sm resize-y focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full px-3 py-2 bg-ctp-mantle border border-ctp-surface1 rounded-lg text-sm resize-y focus:outline-none focus:ring-2 focus:ring-ctp-blue"
             />
           </div>
 
@@ -520,7 +520,7 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
 
           {/* Next turn output mode */}
           <div>
-            <label className="block text-sm text-gray-400 mb-2">
+            <label className="block text-sm text-ctp-subtext0 mb-2">
               Next turn output format
             </label>
             <div className="flex gap-2">
@@ -529,8 +529,8 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
                 onClick={() => setNextOutputMode("md-only")}
                 className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${
                   nextOutputMode === "md-only"
-                    ? "border-blue-500 bg-blue-500/20 text-blue-300"
-                    : "border-gray-700 bg-gray-900 text-gray-400 hover:border-gray-500"
+                    ? "border-ctp-blue bg-ctp-blue/20 text-ctp-blue"
+                    : "border-ctp-surface1 bg-ctp-mantle text-ctp-subtext0 hover:border-ctp-overlay0"
                 }`}
               >
                 Markdown only
@@ -540,8 +540,8 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
                 onClick={() => setNextOutputMode("md-and-artifact")}
                 className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${
                   nextOutputMode === "md-and-artifact"
-                    ? "border-blue-500 bg-blue-500/20 text-blue-300"
-                    : "border-gray-700 bg-gray-900 text-gray-400 hover:border-gray-500"
+                    ? "border-ctp-blue bg-ctp-blue/20 text-ctp-blue"
+                    : "border-ctp-surface1 bg-ctp-mantle text-ctp-subtext0 hover:border-ctp-overlay0"
                 }`}
               >
                 Markdown + HTML artifact

--- a/src/components/outcome-editor.tsx
+++ b/src/components/outcome-editor.tsx
@@ -224,7 +224,7 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
       <div className="flex gap-4" style={{ minHeight: "60vh" }}>
         {/* Left: Answer content */}
         <div className="flex-1 min-w-0 flex flex-col border border-ctp-surface1 rounded-lg overflow-hidden">
-          <div className="flex items-center justify-between px-4 py-2.5 bg-ctp-base border-b border-ctp-surface1 shrink-0">
+          <div className="flex items-center justify-between px-4 py-2.5 bg-ctp-crust border-b border-ctp-surface1 shrink-0">
             <div className="flex items-center gap-3">
               <button
                 type="button"
@@ -317,7 +317,7 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
 
         {/* Right: Outcome sidebar */}
         <div className="w-80 shrink-0 flex flex-col border border-ctp-surface1 rounded-lg overflow-hidden">
-          <div className="flex items-center justify-between px-4 py-2.5 bg-ctp-base border-b border-ctp-surface1 shrink-0">
+          <div className="flex items-center justify-between px-4 py-2.5 bg-ctp-crust border-b border-ctp-surface1 shrink-0">
             <span className="font-medium text-sm text-ctp-subtext1">
               Turn {turn} — Outcome
             </span>
@@ -408,7 +408,7 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
             <button
               type="button"
               onClick={handleAdvance}
-              className="w-full px-3 py-2 bg-ctp-blue hover:bg-ctp-blue-400 text-ctp-crust text-sm rounded transition-colors"
+              className="w-full px-3 py-2 bg-ctp-blue hover:bg-ctp-blue-400 text-ctp-base text-sm rounded transition-colors"
             >
               Advance to Next Turn
             </button>
@@ -436,7 +436,7 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
           </button>
           <button
             onClick={handleAdvance}
-            className="px-4 py-1.5 bg-ctp-blue hover:bg-ctp-blue-400 text-ctp-crust text-sm rounded-md transition-colors"
+            className="px-4 py-1.5 bg-ctp-blue hover:bg-ctp-blue-400 text-ctp-base text-sm rounded-md transition-colors"
           >
             Advance to Next Turn
           </button>

--- a/src/components/pane-viewer.tsx
+++ b/src/components/pane-viewer.tsx
@@ -28,24 +28,24 @@ function ExpandModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-ctp-crust/80 backdrop-blur-sm"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="w-[90vw] h-[85vh] flex flex-col rounded-xl border border-gray-700 bg-gray-950 shadow-2xl overflow-hidden">
-        <div className="flex items-center justify-between px-4 py-2.5 bg-gray-900 border-b border-gray-700">
-          <span className="font-mono text-sm text-gray-300">{name}</span>
+      <div className="w-[90vw] h-[85vh] flex flex-col rounded-xl border border-ctp-surface1 bg-ctp-crust shadow-2xl overflow-hidden">
+        <div className="flex items-center justify-between px-4 py-2.5 bg-ctp-mantle border-b border-ctp-surface1">
+          <span className="font-mono text-sm text-ctp-subtext1">{name}</span>
           <button
             onClick={onClose}
-            className="px-2 py-0.5 text-xs text-gray-400 hover:text-gray-200 border border-gray-700 rounded hover:bg-gray-800 transition-colors"
+            className="px-2 py-0.5 text-xs text-ctp-subtext0 hover:text-ctp-subtext1 border border-ctp-surface1 rounded hover:bg-ctp-base transition-colors"
           >
             ESC
           </button>
         </div>
         <pre
           ref={preRef}
-          className="flex-1 p-4 text-sm font-mono text-green-300 overflow-auto whitespace-pre"
+          className="flex-1 p-4 text-sm font-mono text-ctp-green overflow-auto whitespace-pre"
         >
           {content || "Waiting for output..."}
         </pre>
@@ -65,18 +65,18 @@ export function PaneViewer({
 
   return (
     <>
-      <div className="rounded-lg border border-gray-700 bg-gray-900 overflow-hidden group">
-        <div className="flex items-center justify-between px-3 py-1.5 bg-gray-800 border-b border-gray-700">
-          <span className="text-xs text-gray-400 font-mono">{name}</span>
+      <div className="rounded-lg border border-ctp-surface1 bg-ctp-mantle overflow-hidden group">
+        <div className="flex items-center justify-between px-3 py-1.5 bg-ctp-base border-b border-ctp-surface1">
+          <span className="text-xs text-ctp-subtext0 font-mono">{name}</span>
           <button
             onClick={() => setExpanded(true)}
-            className="text-xs text-gray-500 hover:text-gray-300 opacity-0 group-hover:opacity-100 transition-opacity"
+            className="text-xs text-ctp-overlay0 hover:text-ctp-subtext1 opacity-0 group-hover:opacity-100 transition-opacity"
           >
             Expand
           </button>
         </div>
         <pre
-          className="p-3 text-xs font-mono text-green-300 overflow-x-auto max-h-64 overflow-y-auto whitespace-pre cursor-pointer"
+          className="p-3 text-xs font-mono text-ctp-green overflow-x-auto max-h-64 overflow-y-auto whitespace-pre cursor-pointer"
           onClick={() => setExpanded(true)}
         >
           {content || "Waiting for output..."}

--- a/src/components/pane-viewer.tsx
+++ b/src/components/pane-viewer.tsx
@@ -28,17 +28,17 @@ function ExpandModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-ctp-crust/80 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="w-[90vw] h-[85vh] flex flex-col rounded-xl border border-ctp-surface1 bg-ctp-crust shadow-2xl overflow-hidden">
+      <div className="w-[90vw] h-[85vh] flex flex-col rounded-xl border border-ctp-surface1 bg-ctp-base shadow-2xl overflow-hidden">
         <div className="flex items-center justify-between px-4 py-2.5 bg-ctp-mantle border-b border-ctp-surface1">
           <span className="font-mono text-sm text-ctp-subtext1">{name}</span>
           <button
             onClick={onClose}
-            className="px-2 py-0.5 text-xs text-ctp-subtext0 hover:text-ctp-subtext1 border border-ctp-surface1 rounded hover:bg-ctp-base transition-colors"
+            className="px-2 py-0.5 text-xs text-ctp-subtext0 hover:text-ctp-subtext1 border border-ctp-surface1 rounded hover:bg-ctp-crust transition-colors"
           >
             ESC
           </button>
@@ -66,7 +66,7 @@ export function PaneViewer({
   return (
     <>
       <div className="rounded-lg border border-ctp-surface1 bg-ctp-mantle overflow-hidden group">
-        <div className="flex items-center justify-between px-3 py-1.5 bg-ctp-base border-b border-ctp-surface1">
+        <div className="flex items-center justify-between px-3 py-1.5 bg-ctp-crust border-b border-ctp-surface1">
           <span className="text-xs text-ctp-subtext0 font-mono">{name}</span>
           <button
             onClick={() => setExpanded(true)}

--- a/src/components/participant-panel.tsx
+++ b/src/components/participant-panel.tsx
@@ -14,11 +14,11 @@ export function ParticipantPanel({ name, type, branch, paneContent }: Props) {
     <div className="flex-1 min-w-0">
       <div className="flex items-center gap-2 mb-2">
         <h3 className="font-semibold text-sm">{name}</h3>
-        <span className="text-xs px-1.5 py-0.5 rounded bg-gray-800 text-gray-400">
+        <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-base text-ctp-subtext0">
           {type}
         </span>
       </div>
-      <div className="text-xs text-gray-500 mb-2 font-mono truncate">
+      <div className="text-xs text-ctp-overlay0 mb-2 font-mono truncate">
         {branch}
       </div>
       <PaneViewer content={paneContent ?? ""} name={name} />

--- a/src/components/participant-panel.tsx
+++ b/src/components/participant-panel.tsx
@@ -14,7 +14,7 @@ export function ParticipantPanel({ name, type, branch, paneContent }: Props) {
     <div className="flex-1 min-w-0">
       <div className="flex items-center gap-2 mb-2">
         <h3 className="font-semibold text-sm">{name}</h3>
-        <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-base text-ctp-subtext0">
+        <span className="text-xs px-1.5 py-0.5 rounded bg-ctp-crust text-ctp-subtext0">
           {type}
         </span>
       </div>

--- a/src/components/phase-indicator.tsx
+++ b/src/components/phase-indicator.tsx
@@ -12,7 +12,7 @@ const TERMINAL = ["finalized", "cancelled"] as const;
 
 export function PhaseIndicator({ phase }: { phase: string }) {
   if (TERMINAL.some((t) => t === phase)) {
-    const color = phase === "finalized" ? "text-green-400" : "text-red-400";
+    const color = phase === "finalized" ? "text-ctp-green" : "text-ctp-red";
     return (
       <span className={`text-sm font-medium ${color}`}>
         {phase.toUpperCase()}
@@ -25,9 +25,9 @@ export function PhaseIndicator({ phase }: { phase: string }) {
   return (
     <div className="flex items-center gap-1">
       {PHASES.map((p, i) => {
-        let color = "bg-gray-700";
-        if (i < currentIdx) color = "bg-blue-600";
-        if (i === currentIdx) color = "bg-blue-400 ring-2 ring-blue-300";
+        let color = "bg-ctp-surface1";
+        if (i < currentIdx) color = "bg-ctp-blue";
+        if (i === currentIdx) color = "bg-ctp-blue-400 ring-2 ring-ctp-blue";
         return (
           <div key={p.key} className="flex items-center gap-1">
             <div
@@ -35,12 +35,12 @@ export function PhaseIndicator({ phase }: { phase: string }) {
               title={p.label}
             />
             {i < PHASES.length - 1 && (
-              <div className="w-1 h-0.5 bg-gray-600" />
+              <div className="w-1 h-0.5 bg-ctp-surface2" />
             )}
           </div>
         );
       })}
-      <span className="ml-2 text-xs text-gray-400">
+      <span className="ml-2 text-xs text-ctp-subtext0">
         {PHASES[currentIdx]?.label ?? phase}
       </span>
     </div>

--- a/src/components/review-materials.tsx
+++ b/src/components/review-materials.tsx
@@ -93,17 +93,17 @@ function ContentModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-ctp-crust/80 backdrop-blur-sm"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="w-[85vw] h-[80vh] flex flex-col rounded-xl border border-gray-700 bg-gray-950 shadow-2xl overflow-hidden">
-        <div className="flex items-center justify-between px-5 py-3 bg-gray-900 border-b border-gray-700">
-          <span className="font-medium text-sm text-gray-200">{title}</span>
+      <div className="w-[85vw] h-[80vh] flex flex-col rounded-xl border border-ctp-surface1 bg-ctp-crust shadow-2xl overflow-hidden">
+        <div className="flex items-center justify-between px-5 py-3 bg-ctp-mantle border-b border-ctp-surface1">
+          <span className="font-medium text-sm text-ctp-subtext1">{title}</span>
           <button
             onClick={onClose}
-            className="px-2 py-0.5 text-xs text-gray-400 hover:text-gray-200 border border-gray-700 rounded hover:bg-gray-800 transition-colors"
+            className="px-2 py-0.5 text-xs text-ctp-subtext0 hover:text-ctp-subtext1 border border-ctp-surface1 rounded hover:bg-ctp-base transition-colors"
           >
             ESC
           </button>
@@ -144,16 +144,16 @@ function SubmissionCard({
 
   return (
     <>
-      <div className="border border-gray-700 rounded-lg overflow-hidden group">
+      <div className="border border-ctp-surface1 rounded-lg overflow-hidden group">
         <button
           type="button"
           onClick={() => setCollapsed(!collapsed)}
-          className="w-full flex items-center justify-between px-4 py-2.5 bg-gray-800 hover:bg-gray-800/80 transition-colors"
+          className="w-full flex items-center justify-between px-4 py-2.5 bg-ctp-base hover:bg-ctp-base/80 transition-colors"
         >
-          <span className="font-medium text-sm text-gray-200">
+          <span className="font-medium text-sm text-ctp-subtext1">
             {submission.name}
           </span>
-          <span className="text-xs text-gray-500">
+          <span className="text-xs text-ctp-overlay0">
             {collapsed ? "▸" : "▾"}
           </span>
         </button>
@@ -161,14 +161,14 @@ function SubmissionCard({
         {!collapsed && (
           <div>
             {/* Round tabs + expand */}
-            <div className="flex border-b border-gray-700">
+            <div className="flex border-b border-ctp-surface1">
               <button
                 type="button"
                 onClick={() => setActiveTab("r1")}
                 className={`flex-1 px-3 py-1.5 text-xs transition-colors ${
                   activeTab === "r1"
-                    ? "text-blue-300 border-b-2 border-blue-400 bg-gray-900"
-                    : "text-gray-500 hover:text-gray-300"
+                    ? "text-ctp-blue border-b-2 border-ctp-blue bg-ctp-mantle"
+                    : "text-ctp-overlay0 hover:text-ctp-subtext1"
                 }`}
               >
                 Round 1 — Independent
@@ -178,8 +178,8 @@ function SubmissionCard({
                 onClick={() => setActiveTab("r2")}
                 className={`flex-1 px-3 py-1.5 text-xs transition-colors ${
                   activeTab === "r2"
-                    ? "text-blue-300 border-b-2 border-blue-400 bg-gray-900"
-                    : "text-gray-500 hover:text-gray-300"
+                    ? "text-ctp-blue border-b-2 border-ctp-blue bg-ctp-mantle"
+                    : "text-ctp-overlay0 hover:text-ctp-subtext1"
                 }`}
               >
                 Round 2 — Refined
@@ -191,24 +191,24 @@ function SubmissionCard({
                     ? onExpand(index!, activeTab)
                     : setModal(true)
                 }
-                className="px-3 py-1.5 text-xs text-gray-500 hover:text-gray-300 border-l border-gray-700 transition-colors"
+                className="px-3 py-1.5 text-xs text-ctp-overlay0 hover:text-ctp-subtext1 border-l border-ctp-surface1 transition-colors"
               >
                 Expand
               </button>
             </div>
 
             {/* Content */}
-            <div className="p-4 max-h-80 overflow-y-auto bg-gray-900/30">
+            <div className="p-4 max-h-80 overflow-y-auto bg-ctp-mantle/30">
               {content ? (
                 <Markdown content={content} />
               ) : (
-                <p className="text-gray-500 text-sm italic">No submission</p>
+                <p className="text-ctp-overlay0 text-sm italic">No submission</p>
               )}
             </div>
 
             {/* Artifact preview */}
             {submission.hasArtifact && sessionId && turn != null && (
-              <div className="p-4 border-t border-gray-700">
+              <div className="p-4 border-t border-ctp-surface1">
                 <ArtifactPreview
                   sessionId={sessionId}
                   participant={submission.name}
@@ -256,9 +256,9 @@ function RoundViewCard({
 
   return (
     <>
-      <div className="border border-gray-700 rounded-lg overflow-hidden group">
-        <div className="flex items-center justify-between px-4 py-2 bg-gray-800 border-b border-gray-700">
-          <span className="font-medium text-sm text-gray-200">{name}</span>
+      <div className="border border-ctp-surface1 rounded-lg overflow-hidden group">
+        <div className="flex items-center justify-between px-4 py-2 bg-ctp-base border-b border-ctp-surface1">
+          <span className="font-medium text-sm text-ctp-subtext1">{name}</span>
           <button
             type="button"
             onClick={() =>
@@ -266,21 +266,21 @@ function RoundViewCard({
                 ? onExpand(index!, round!)
                 : setModal(true)
             }
-            className="text-xs text-gray-500 hover:text-gray-300 opacity-0 group-hover:opacity-100 transition-opacity"
+            className="text-xs text-ctp-overlay0 hover:text-ctp-subtext1 opacity-0 group-hover:opacity-100 transition-opacity"
           >
             Expand
           </button>
         </div>
-        <div className="p-4 max-h-80 overflow-y-auto bg-gray-900/30">
+        <div className="p-4 max-h-80 overflow-y-auto bg-ctp-mantle/30">
           {content ? (
             <Markdown content={content} />
           ) : (
-            <p className="text-gray-500 text-sm italic">No submission</p>
+            <p className="text-ctp-overlay0 text-sm italic">No submission</p>
           )}
         </div>
 
         {hasArtifact && sessionId && turn != null && (
-          <div className="p-4 border-t border-gray-700">
+          <div className="p-4 border-t border-ctp-surface1">
             <ArtifactPreview
               sessionId={sessionId}
               participant={name}
@@ -355,30 +355,30 @@ export function ReviewMaterials({
   if (submissions.length === 0) return null;
 
   return (
-    <div className="border border-gray-700 rounded-lg overflow-hidden">
+    <div className="border border-ctp-surface1 rounded-lg overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2.5 bg-gray-800">
+      <div className="flex items-center justify-between px-4 py-2.5 bg-ctp-base">
         <button
           type="button"
           onClick={() => setOpen(!open)}
-          className="flex items-center gap-2 text-sm font-medium text-gray-300 hover:text-gray-100 transition-colors"
+          className="flex items-center gap-2 text-sm font-medium text-ctp-subtext1 hover:text-ctp-text transition-colors"
         >
-          <span className="text-xs text-gray-500">{open ? "▾" : "▸"}</span>
+          <span className="text-xs text-ctp-overlay0">{open ? "▾" : "▸"}</span>
           Participant Submissions
-          <span className="text-xs text-gray-500 font-normal">
+          <span className="text-xs text-ctp-overlay0 font-normal">
             ({submissions.length} participants)
           </span>
         </button>
 
         {open && (
-          <div className="flex gap-1 bg-gray-900 rounded-md p-0.5">
+          <div className="flex gap-1 bg-ctp-mantle rounded-md p-0.5">
             <button
               type="button"
               onClick={() => setViewMode("participants")}
               className={`px-2.5 py-1 text-xs rounded transition-colors ${
                 viewMode === "participants"
-                  ? "bg-gray-700 text-gray-200"
-                  : "text-gray-500 hover:text-gray-300"
+                  ? "bg-ctp-surface0 text-ctp-subtext1"
+                  : "text-ctp-overlay0 hover:text-ctp-subtext1"
               }`}
             >
               By Participant
@@ -388,8 +388,8 @@ export function ReviewMaterials({
               onClick={() => setViewMode("rounds")}
               className={`px-2.5 py-1 text-xs rounded transition-colors ${
                 viewMode === "rounds"
-                  ? "bg-gray-700 text-gray-200"
-                  : "text-gray-500 hover:text-gray-300"
+                  ? "bg-ctp-surface0 text-ctp-subtext1"
+                  : "text-ctp-overlay0 hover:text-ctp-subtext1"
               }`}
             >
               By Round
@@ -421,8 +421,8 @@ export function ReviewMaterials({
                   onClick={() => setRoundTab("r1")}
                   className={`px-3 py-1.5 text-sm rounded-md border transition-colors ${
                     roundTab === "r1"
-                      ? "border-blue-500 bg-blue-500/20 text-blue-300"
-                      : "border-gray-700 text-gray-400 hover:border-gray-500"
+                      ? "border-ctp-blue bg-ctp-blue/20 text-ctp-blue"
+                      : "border-ctp-surface1 text-ctp-subtext0 hover:border-ctp-overlay0"
                   }`}
                 >
                   Round 1 — Independent Answers
@@ -432,8 +432,8 @@ export function ReviewMaterials({
                   onClick={() => setRoundTab("r2")}
                   className={`px-3 py-1.5 text-sm rounded-md border transition-colors ${
                     roundTab === "r2"
-                      ? "border-blue-500 bg-blue-500/20 text-blue-300"
-                      : "border-gray-700 text-gray-400 hover:border-gray-500"
+                      ? "border-ctp-blue bg-ctp-blue/20 text-ctp-blue"
+                      : "border-ctp-surface1 text-ctp-subtext0 hover:border-ctp-overlay0"
                   }`}
                 >
                   Round 2 — Refined Views

--- a/src/components/review-materials.tsx
+++ b/src/components/review-materials.tsx
@@ -93,17 +93,17 @@ function ContentModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-ctp-crust/80 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="w-[85vw] h-[80vh] flex flex-col rounded-xl border border-ctp-surface1 bg-ctp-crust shadow-2xl overflow-hidden">
+      <div className="w-[85vw] h-[80vh] flex flex-col rounded-xl border border-ctp-surface1 bg-ctp-base shadow-2xl overflow-hidden">
         <div className="flex items-center justify-between px-5 py-3 bg-ctp-mantle border-b border-ctp-surface1">
           <span className="font-medium text-sm text-ctp-subtext1">{title}</span>
           <button
             onClick={onClose}
-            className="px-2 py-0.5 text-xs text-ctp-subtext0 hover:text-ctp-subtext1 border border-ctp-surface1 rounded hover:bg-ctp-base transition-colors"
+            className="px-2 py-0.5 text-xs text-ctp-subtext0 hover:text-ctp-subtext1 border border-ctp-surface1 rounded hover:bg-ctp-crust transition-colors"
           >
             ESC
           </button>
@@ -148,7 +148,7 @@ function SubmissionCard({
         <button
           type="button"
           onClick={() => setCollapsed(!collapsed)}
-          className="w-full flex items-center justify-between px-4 py-2.5 bg-ctp-base hover:bg-ctp-base/80 transition-colors"
+          className="w-full flex items-center justify-between px-4 py-2.5 bg-ctp-crust hover:bg-ctp-crust/80 transition-colors"
         >
           <span className="font-medium text-sm text-ctp-subtext1">
             {submission.name}
@@ -257,7 +257,7 @@ function RoundViewCard({
   return (
     <>
       <div className="border border-ctp-surface1 rounded-lg overflow-hidden group">
-        <div className="flex items-center justify-between px-4 py-2 bg-ctp-base border-b border-ctp-surface1">
+        <div className="flex items-center justify-between px-4 py-2 bg-ctp-crust border-b border-ctp-surface1">
           <span className="font-medium text-sm text-ctp-subtext1">{name}</span>
           <button
             type="button"
@@ -357,7 +357,7 @@ export function ReviewMaterials({
   return (
     <div className="border border-ctp-surface1 rounded-lg overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2.5 bg-ctp-base">
+      <div className="flex items-center justify-between px-4 py-2.5 bg-ctp-crust">
         <button
           type="button"
           onClick={() => setOpen(!open)}

--- a/src/components/session-card.tsx
+++ b/src/components/session-card.tsx
@@ -40,7 +40,7 @@ export function SessionCard({
           {participants.map((p) => (
             <span
               key={p.name}
-              className="text-xs px-1.5 py-0.5 rounded bg-ctp-base text-ctp-subtext0"
+              className="text-xs px-1.5 py-0.5 rounded bg-ctp-crust text-ctp-subtext0"
             >
               {p.name}
             </span>

--- a/src/components/session-card.tsx
+++ b/src/components/session-card.tsx
@@ -21,17 +21,17 @@ export function SessionCard({
   return (
     <Link
       href={`/session/${sessionId}`}
-      className="block p-4 rounded-lg border border-gray-800 hover:border-gray-600 bg-gray-900/50 hover:bg-gray-900 transition-colors"
+      className="block p-4 rounded-lg border border-ctp-surface0 hover:border-ctp-surface2 bg-ctp-mantle/50 hover:bg-ctp-mantle transition-colors"
     >
       <div className="flex items-start justify-between mb-2">
         <h3 className="font-semibold text-sm truncate flex-1">
           {topic.split("\n")[0]}
         </h3>
-        <span className="text-xs text-gray-500 ml-2 shrink-0">
+        <span className="text-xs text-ctp-overlay0 ml-2 shrink-0">
           Turn {currentTurn}
         </span>
       </div>
-      <div className="text-xs text-gray-500 font-mono mb-3 truncate">
+      <div className="text-xs text-ctp-overlay0 font-mono mb-3 truncate">
         {sessionId}
       </div>
       <div className="flex items-center justify-between">
@@ -40,7 +40,7 @@ export function SessionCard({
           {participants.map((p) => (
             <span
               key={p.name}
-              className="text-xs px-1.5 py-0.5 rounded bg-gray-800 text-gray-400"
+              className="text-xs px-1.5 py-0.5 rounded bg-ctp-base text-ctp-subtext0"
             >
               {p.name}
             </span>


### PR DESCRIPTION
## Summary

- Install `@catppuccin/tailwindcss` and import Mocha flavor in `globals.css`
- Replace all hardcoded Tailwind gray/blue/red/green colors with Catppuccin Mocha semantic tokens across 15 UI files
- Color mapping: `gray-950→ctp-crust`, `gray-900→ctp-mantle`, `gray-800→ctp-base`, surfaces/overlays/subtexts for mid-tones, `ctp-blue`/`ctp-red`/`ctp-green` for accents

## Test plan

- [ ] Run `bun dev` and visually verify the home page (session list, "New Session" button)
- [ ] Open a session detail page — check status bar, participant panels, pane viewer
- [ ] Expand a pane modal — verify backdrop and terminal-green text
- [ ] Open the outcome editor — verify kind selector, textareas, review materials
- [ ] Check the create-session form — topic input, participant toggle buttons, dir picker
- [ ] Verify prose/markdown rendering colors in outcome and review panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)