### PR TITLE
feat: support adding participants at turn boundaries

### DIFF
--- a/__tests__/lib/orchestrator.test.ts
+++ b/__tests__/lib/orchestrator.test.ts
@@ -16,9 +16,12 @@ import {
   loadSession,
   PHASE_OUTCOME_PENDING,
   PHASE_ROUND_1_DONE,
+  PHASE_INIT,
   _draftOutcome,
   _deliverOutcomeToParticipants,
   _resolveSessionPaths,
+  _cleanWorktreeForLateJoiner,
+  addParticipantToSession,
   advanceToNextTurn,
   finalize,
 } from "@/lib/orchestrator";
@@ -742,5 +745,184 @@ describe("advance commits dirty outcome", () => {
       "utf-8",
     );
     expect(delivered.trimEnd()).toBe("USER-CONFIRMED-V2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanWorktreeForLateJoiner
+// ---------------------------------------------------------------------------
+
+describe("cleanWorktreeForLateJoiner", () => {
+  it("strips review materials from outcome.md", () => {
+    const repo = makeRepo();
+    fs.writeFileSync(path.join(repo, "00_topic.md"), "topic");
+    gitOps.commit(repo, "init");
+
+    // Simulate main having an unstripped outcome
+    fs.mkdirSync(path.join(repo, "turn-1"), { recursive: true });
+    fs.writeFileSync(
+      path.join(repo, "turn-1", "outcome.md"),
+      "# Decision\nKeep it simple\n\n" +
+        REVIEW_BEGIN_MARKER +
+        "\n## alice\nraw answer\n" +
+        REVIEW_END_MARKER +
+        "\n",
+    );
+    gitOps.commit(repo, "draft outcome");
+
+    // Create a worktree branching from main (simulating late joiner)
+    const wt = path.join(tmpDir, "wt-new");
+    gitOps.addWorktree(repo, wt, "participant/s/newcomer");
+
+    _cleanWorktreeForLateJoiner(wt, 1, ["alice"]);
+
+    const content = fs.readFileSync(
+      path.join(wt, "turn-1", "outcome.md"),
+      "utf-8",
+    );
+    expect(content).toContain("Keep it simple");
+    expect(content).not.toContain(REVIEW_BEGIN_MARKER);
+    expect(content).not.toContain("raw answer");
+
+    // Should have committed the cleanup
+    const subjects = gitOps.logSubjects(repo, "participant/s/newcomer");
+    expect(
+      subjects.some((s) => s.includes("clean worktree for late joiner")),
+    ).toBe(true);
+  });
+
+  it("removes other participants' artifact directories", () => {
+    const repo = makeRepo();
+    fs.writeFileSync(path.join(repo, "00_topic.md"), "topic");
+    gitOps.commit(repo, "init");
+
+    // Simulate main having artifact dirs from draftOutcome
+    fs.mkdirSync(path.join(repo, "turn-1", "alice", "artifact"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(repo, "turn-1", "alice", "artifact", "index.html"),
+      "<html>alice prototype</html>",
+    );
+    fs.mkdirSync(path.join(repo, "turn-1"), { recursive: true });
+    fs.writeFileSync(
+      path.join(repo, "turn-1", "outcome.md"),
+      "# Decision\nFoo\n",
+    );
+    gitOps.commit(repo, "draft outcome with artifacts");
+
+    const wt = path.join(tmpDir, "wt-new");
+    gitOps.addWorktree(repo, wt, "participant/s/newcomer");
+
+    // Verify artifact exists before cleanup
+    expect(
+      fs.existsSync(
+        path.join(wt, "turn-1", "alice", "artifact", "index.html"),
+      ),
+    ).toBe(true);
+
+    _cleanWorktreeForLateJoiner(wt, 1, ["alice"]);
+
+    // Artifact directory should be gone
+    expect(fs.existsSync(path.join(wt, "turn-1", "alice"))).toBe(false);
+    // Outcome should still be there (no review materials to strip)
+    expect(
+      fs.readFileSync(path.join(wt, "turn-1", "outcome.md"), "utf-8"),
+    ).toContain("Foo");
+  });
+
+  it("handles multiple turns", () => {
+    const repo = makeRepo();
+    fs.writeFileSync(path.join(repo, "00_topic.md"), "topic");
+    gitOps.commit(repo, "init");
+
+    for (const t of [1, 2]) {
+      fs.mkdirSync(path.join(repo, `turn-${t}`), { recursive: true });
+      fs.writeFileSync(
+        path.join(repo, `turn-${t}`, "outcome.md"),
+        `# Turn ${t}\n\n` +
+          REVIEW_BEGIN_MARKER +
+          `\nraw data ${t}\n` +
+          REVIEW_END_MARKER +
+          "\n",
+      );
+    }
+    gitOps.commit(repo, "outcomes");
+
+    const wt = path.join(tmpDir, "wt-new");
+    gitOps.addWorktree(repo, wt, "participant/s/newcomer");
+
+    _cleanWorktreeForLateJoiner(wt, 2, []);
+
+    for (const t of [1, 2]) {
+      const content = fs.readFileSync(
+        path.join(wt, `turn-${t}`, "outcome.md"),
+        "utf-8",
+      );
+      expect(content).toContain(`Turn ${t}`);
+      expect(content).not.toContain(REVIEW_BEGIN_MARKER);
+      expect(content).not.toContain(`raw data ${t}`);
+    }
+  });
+
+  it("no-op when worktree is already clean", () => {
+    const repo = makeRepo();
+    fs.writeFileSync(path.join(repo, "00_topic.md"), "topic");
+    gitOps.commit(repo, "init");
+
+    const wt = path.join(tmpDir, "wt-new");
+    gitOps.addWorktree(repo, wt, "participant/s/newcomer");
+
+    // No turn directories — should not throw or create commits
+    const subjectsBefore = gitOps.logSubjects(repo, "participant/s/newcomer");
+    _cleanWorktreeForLateJoiner(wt, 1, []);
+    const subjectsAfter = gitOps.logSubjects(repo, "participant/s/newcomer");
+    expect(subjectsAfter.length).toBe(subjectsBefore.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addParticipantToSession
+// ---------------------------------------------------------------------------
+
+describe("addParticipantToSession", () => {
+  const testProfile: AgentProfile = {
+    name: "newcomer",
+    cli: "bash",
+    flags: [],
+    env: {},
+    postStartKeys: [],
+    postStartDelay: 0,
+  };
+
+  it("rejects wrong phase", async () => {
+    const session = makeTestSession();
+    session.currentPhase = PHASE_ROUND_1_DONE;
+    await expect(
+      addParticipantToSession(session, {
+        profileName: "newcomer",
+        agentProfiles: { newcomer: testProfile },
+      }),
+    ).rejects.toThrow(/phase/);
+  });
+
+  it("rejects duplicate name", async () => {
+    const session = makeTestSession();
+    await expect(
+      addParticipantToSession(session, {
+        profileName: "claude-sonnet",
+        agentProfiles: { "claude-sonnet": testProfile },
+      }),
+    ).rejects.toThrow(/already exists/);
+  });
+
+  it("rejects unknown profile", async () => {
+    const session = makeTestSession();
+    await expect(
+      addParticipantToSession(session, {
+        profileName: "nonexistent",
+        agentProfiles: {},
+      }),
+    ).rejects.toThrow(/Unknown agent profile/);
   });
 });

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -268,3 +268,38 @@ env = { ANTHROPIC_OAUTH_TOKEN = "..." }
 - Python 文件（brainstormd/、tests/、pyproject.toml、uv.lock、.python-version）已删除
 
 ---
+
+## ADR-009 · 支持在 turn 边界加入新 participant（2026-04-28）
+
+**状态：** Accepted
+
+**决策：** 允许在 session 处于 `outcome-pending` 状态时（即人编辑完 outcome、尚未 advance 到下一 turn）向 session 添加新 participant。新 participant 从下一 turn 开始正式参与 round-1 / round-2。
+
+具体流程：
+1. 从 main 创建 worktree + branch（`participant/<session>/<name>`）
+2. 清理 worktree：strip 所有 `turn-*/outcome.md` 的 review materials，删除 main 上其他 participant 的 artifact 目录
+3. 启动 TUI agent，完成 boot handshake
+4. 加入 `session.participants` 数组，保存 manifest
+5. 后续 advance 时，新 participant 与原有 participant 一起接收 stripped outcome 并进入新 turn
+
+**上下文：** 用户希望在 brainstorm 进行中根据讨论走向加入新 agent。例如前两 turn 用两个 model 讨论，第三 turn 加入第三个 model 以引入新视角。
+
+**理由：**
+- Turn 边界是唯一安全的加入点：outcome 已确认、没有进行中的 round 隔离需要维护。Mid-round 加入会破坏 round-1 互盲不变量（新 participant 无法公平参与已进行的 round）
+- 新 participant 的 worktree 从 main 分支创建。Main 上有带 review materials 的 outcome + draftOutcome 拷贝的 artifact 目录。这些必须清理，否则新 participant 看到了原始答卷（通过 review block）和其他 participant 的 artifact——违反隔离原则
+- Boot handshake 确保 TUI agent 已启动并理解协议后才参与；与 session 创建时的 boot 流程一致
+- 现有 `advanceToNextTurn` 遍历 `session.participants` 发送任务和收集答卷——新 participant 加入后自然被包含，无需修改 phase runner
+
+**考虑过的替代方案：**
+- Mid-round 加入（round-1 或 round-2 进行中）→ 破坏 round 隔离不变量；需要重新生成 pool 或跳过当前 round，复杂且脆弱
+- 从空白分支创建 worktree（不基于 main）→ 新 participant 缺少 topic、rules、prior outcomes，需要逐一投递，工作量大且容易遗漏
+- 不清理 main 上的 review materials → 新 participant 能读到上一轮所有人的 raw 答卷，违反 ADR-006 "投递时 strip" 的精神
+
+**结论 / 后续：**
+- `orchestrator.addParticipantToSession()` 实现核心逻辑；`cleanWorktreeForLateJoiner()` 处理 worktree 清理
+- API: `POST /api/sessions/[id]/participants`，body `{ profileName }`
+- Web UI: session 详情页在 `outcome-pending` 状态下显示 "+ Add Participant" 按钮
+- SSE 事件 `participant:added` 通知前端
+- 7 个新测试覆盖：cleanWorktreeForLateJoiner（strip outcomes、remove artifacts、multi-turn、no-op）+ addParticipantToSession（phase 校验、重名校验、未知 profile 校验）
+
+---

--- a/docs/design.md
+++ b/docs/design.md
@@ -102,6 +102,7 @@ Send-keys 只是 wake signal，内容在文件——避免 tmux 转义 / 引号 
 - **Participant 抽象 + task.md 唤醒协议**（ADR-005）：agent + human 协议层等价
 - **Outcome.md 嵌入答卷供人 review，投递时 strip**（ADR-006）：同一份 outcome.md 在 vault 里给人看时带答卷，给下一 turn agent 看时只剩决定
 - **Artifact 支持**（ADR-007）：session 级 `outputMode` 控制 participant 是否产出 HTML 原型（`artifact.html`）；Web UI 用 sandboxed iframe 预览
+- **Turn 边界加人**（ADR-009）：`outcome-pending` 状态下可通过 Web UI 向 session 添加新 participant；新 participant 的 worktree 从 main 创建并清理（strip outcomes + 删除其他 participant 的 artifact 目录），完成 boot 后参与后续 turn
 
 ## 仓库 / vault 布局
 
@@ -267,8 +268,9 @@ Finalize 后 vault main 上能看到所有 participant 的 raw `answer.md` / `re
 - Filesystem-only（无 SQLite）
 - 只实现 TUIAgent（无 Human，留 stub）
 - 无 role 注入（协议槽位留好）
+- Turn 边界加人：`outcome-pending` 状态下可通过 Web UI 添加新 agent participant
 
-技术栈：TypeScript + Bun + Next.js (App Router) + Tailwind CSS + Vitest（86 个测试）
+技术栈：TypeScript + Bun + Next.js (App Router) + Tailwind CSS + Vitest（93 个测试）
 
 验证过的三件事：
 1. tmux send-keys + task.md 读取链路稳

--- a/src/app/api/sessions/[id]/participants/route.ts
+++ b/src/app/api/sessions/[id]/participants/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { sessionStore } from "@/lib/session-store";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  let profileName: string;
+  try {
+    const body = await request.json();
+    profileName = body.profileName;
+  } catch {
+    return NextResponse.json(
+      { error: "Request body must include profileName" },
+      { status: 400 },
+    );
+  }
+  if (!profileName || typeof profileName !== "string") {
+    return NextResponse.json(
+      { error: "profileName must be a non-empty string" },
+      { status: 400 },
+    );
+  }
+  try {
+    sessionStore.addParticipant(id, profileName);
+    return NextResponse.json(
+      { status: "adding", profileName },
+      { status: 202 },
+    );
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 400 },
+    );
+  }
+}

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -9,6 +9,7 @@ import { ParticipantPanel } from "@/components/participant-panel";
 import { OutcomeEditor } from "@/components/outcome-editor";
 import { EventLog } from "@/components/event-log";
 import { Markdown } from "@/components/markdown";
+import { AddParticipantButton } from "@/components/add-participant";
 
 const PHASE_LABELS: Record<string, string> = {
   init: "Initializing session...",
@@ -202,6 +203,15 @@ export default function SessionPage({
             paneContent={paneContents[p.name]}
           />
         ))}
+        {isOutcomePending && (
+          <div className="flex items-start">
+            <AddParticipantButton
+              sessionId={id}
+              existingNames={session.participants.map((p) => p.name)}
+              onAdded={refresh}
+            />
+          </div>
+        )}
       </div>
 
       {/* Outcome editor (when outcome-pending) */}

--- a/src/components/add-participant.tsx
+++ b/src/components/add-participant.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface AgentProfile {
+  name: string;
+  cli: string;
+}
+
+export function AddParticipantButton({
+  sessionId,
+  existingNames,
+  onAdded,
+}: {
+  sessionId: string;
+  existingNames: string[];
+  onAdded: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [profiles, setProfiles] = useState<Record<string, AgentProfile>>({});
+  const [adding, setAdding] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    fetch("/api/agents")
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.profiles) setProfiles(data.profiles);
+      })
+      .catch(() => {});
+  }, [open]);
+
+  const existingSet = new Set(existingNames);
+  const available = Object.entries(profiles).filter(
+    ([name]) => !existingSet.has(name),
+  );
+
+  const handleAdd = async (name: string) => {
+    setAdding(name);
+    setError(null);
+    try {
+      const res = await fetch(`/api/sessions/${sessionId}/participants`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ profileName: name }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to add participant");
+        return;
+      }
+      setOpen(false);
+      onAdded();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setAdding(null);
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="px-3 py-1.5 text-sm border border-ctp-blue/50 text-ctp-blue hover:bg-ctp-blue/15 rounded-md transition-colors"
+      >
+        + Add Participant
+      </button>
+    );
+  }
+
+  return (
+    <div className="p-3 rounded-lg border border-ctp-surface1 bg-ctp-mantle space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-ctp-subtext0">Add participant</span>
+        <button
+          onClick={() => { setOpen(false); setError(null); }}
+          className="text-xs text-ctp-overlay0 hover:text-ctp-subtext1"
+        >
+          Cancel
+        </button>
+      </div>
+      {available.length === 0 ? (
+        <p className="text-xs text-ctp-overlay0">
+          No additional profiles available in agents.toml.
+        </p>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {available.map(([name, p]) => (
+            <button
+              key={name}
+              onClick={() => handleAdd(name)}
+              disabled={adding !== null}
+              className="px-3 py-1.5 rounded-lg text-sm border border-ctp-surface1 bg-ctp-base text-ctp-subtext0 hover:border-ctp-blue hover:text-ctp-blue transition-colors disabled:opacity-50"
+            >
+              {adding === name ? "Adding..." : name}
+              <span className="ml-1.5 text-xs opacity-60">{p.cli}</span>
+            </button>
+          ))}
+        </div>
+      )}
+      {error && <div className="text-ctp-red text-xs">{error}</div>}
+    </div>
+  );
+}

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -5,7 +5,8 @@ export type EventType =
   | "session:log"
   | "session:cancelled"
   | "session:finalized"
-  | "participant:pane-update";
+  | "participant:pane-update"
+  | "participant:added";
 
 export interface SessionEvent {
   type: EventType;

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -327,6 +327,7 @@ export { draftOutcome as _draftOutcome };
 export { deliverOutcomeToParticipants as _deliverOutcomeToParticipants };
 export { commitPendingMainChanges as _commitPendingMainChanges };
 export { resolveSessionPaths as _resolveSessionPaths };
+export { cleanWorktreeForLateJoiner as _cleanWorktreeForLateJoiner };
 
 function writeTask(
   participant: Participant,
@@ -587,6 +588,127 @@ function deliverOutcomeToParticipants(session: Session): void {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Add participant at turn boundary
+// ---------------------------------------------------------------------------
+
+export interface AddParticipantOptions {
+  profileName: string;
+  agentProfiles: Record<string, AgentProfile>;
+  bootSettleSeconds?: number;
+}
+
+export async function addParticipantToSession(
+  session: Session,
+  opts: AddParticipantOptions,
+  signal?: AbortSignal,
+): Promise<Participant> {
+  if (session.currentPhase !== PHASE_OUTCOME_PENDING) {
+    throw new Error(
+      `Cannot add participant: session is in phase ${JSON.stringify(session.currentPhase)}, ` +
+        `expected ${JSON.stringify(PHASE_OUTCOME_PENDING)}`,
+    );
+  }
+
+  const { profileName, agentProfiles } = opts;
+
+  if (session.participants.some((p) => p.name === profileName)) {
+    throw new Error(
+      `Participant ${JSON.stringify(profileName)} already exists in this session`,
+    );
+  }
+
+  const profile = agentProfiles[profileName];
+  if (!profile) {
+    throw new Error(
+      `Unknown agent profile: ${JSON.stringify(profileName)}. ` +
+        `Available: ${JSON.stringify(Object.keys(agentProfiles).sort())}`,
+    );
+  }
+
+  const worktree = path.join(session.privateWorkspaces, profileName);
+  gitOps.addWorktree(
+    session.repoPath,
+    worktree,
+    `participant/${session.sessionId}/${profileName}`,
+  );
+
+  // The worktree starts from main which has unstripped outcomes and
+  // artifact directories from other participants (copied for human review).
+  // Clean them up so the new participant only sees stripped outcomes.
+  cleanWorktreeForLateJoiner(
+    worktree,
+    session.currentTurn,
+    session.participants.map((p) => p.name),
+  );
+
+  const agent = new TUIAgent(
+    profileName,
+    session.sessionId,
+    worktree,
+    profile,
+  );
+  agent.start();
+  session.participants.push(agent);
+  session.saveManifest();
+
+  await sleep((opts.bootSettleSeconds ?? 8) * 1000);
+
+  const text = prompts.bootTask(profileName, session.sessionId);
+  writeTask(agent, text, "boot");
+  const statusDir = path.join(worktree, ".brainstorm", "status");
+  fs.mkdirSync(statusDir, { recursive: true });
+  agent.wakeFor("boot");
+
+  await gitOps.waitForSubject(
+    session.repoPath,
+    agent.branch,
+    prompts.readySubject(profileName),
+    2.0,
+    null,
+    signal,
+  );
+
+  session.saveManifest();
+  return agent;
+}
+
+function cleanWorktreeForLateJoiner(
+  worktreePath: string,
+  currentTurn: number,
+  existingParticipantNames: string[],
+): void {
+  let dirty = false;
+  for (let t = 1; t <= currentTurn; t++) {
+    const turnDir = path.join(worktreePath, `turn-${t}`);
+    if (!fs.existsSync(turnDir)) continue;
+
+    // Strip review materials from outcome.md
+    const outcomePath = path.join(turnDir, "outcome.md");
+    if (fs.existsSync(outcomePath)) {
+      const content = fs.readFileSync(outcomePath, "utf-8");
+      const stripped = stripReviewMaterials(content);
+      if (stripped !== content) {
+        fs.writeFileSync(outcomePath, stripped);
+        dirty = true;
+      }
+    }
+
+    // Remove other participants' directories (artifact dirs copied to main for review)
+    for (const name of existingParticipantNames) {
+      const participantDir = path.join(turnDir, name);
+      if (fs.existsSync(participantDir)) {
+        fs.rmSync(participantDir, { recursive: true, force: true });
+        dirty = true;
+      }
+    }
+  }
+
+  if (dirty) {
+    gitOps.commit(worktreePath, "setup: clean worktree for late joiner");
+  }
 }
 
 export interface CreateSessionOptions {

--- a/src/lib/session-store.ts
+++ b/src/lib/session-store.ts
@@ -213,6 +213,49 @@ export class SessionStore {
     return result;
   }
 
+  addParticipant(sessionId: string, profileName: string): void {
+    const session = this.getSession(sessionId);
+    if (!session) throw new Error(`Session ${sessionId} not found`);
+
+    const profiles = loadAgentProfiles(this.agentsTomlPath);
+
+    const controller = new AbortController();
+    this.abortControllers.set(sessionId, controller);
+
+    this.emit({
+      type: "participant:added",
+      sessionId,
+      timestamp: Date.now(),
+      participantName: profileName,
+      message: `Adding participant: ${profileName}`,
+    });
+
+    orchestrator
+      .addParticipantToSession(
+        session,
+        { profileName, agentProfiles: profiles },
+        controller.signal,
+      )
+      .then(() => {
+        this.emit({
+          type: "session:phase-changed",
+          sessionId,
+          timestamp: Date.now(),
+          phase: session.currentPhase,
+          turn: session.currentTurn,
+        });
+        this.startPaneCapture(sessionId);
+      })
+      .catch((err) => {
+        this.emit({
+          type: "session:error",
+          sessionId,
+          timestamp: Date.now(),
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+  }
+
   updateOutcome(sessionId: string, content: string): void {
     const session = this.getSession(sessionId);
     if (!session) throw new Error(`Session ${sessionId} not found`);


### PR DESCRIPTION
## Summary

- Add new agent participants to an in-progress session at turn boundaries (outcome-pending state)
- New participant's worktree is created from main, cleaned up (review materials stripped, other participants' artifact dirs removed), booted via standard handshake, then joins subsequent turns
- Web UI shows "+ Add Participant" button in session detail page when outcome-pending, with profile picker that filters out already-active agents

## Changes

- `orchestrator.ts`: `addParticipantToSession()` + `cleanWorktreeForLateJoiner()`
- `session-store.ts`: `addParticipant()` method with SSE event emission
- `events.ts`: new `participant:added` event type
- `POST /api/sessions/[id]/participants`: new API endpoint
- `add-participant.tsx`: new UI component
- `session/[id]/page.tsx`: integrate add-participant button
- `decisions.md`: ADR-009
- 7 new tests (93 total), all passing

## Test plan

- [x] `bun test` — 93 tests pass
- [x] `tsc --noEmit` — clean type-check
- [ ] Manual: start a 2-agent session, complete turn 1, click "+ Add Participant" in outcome-pending state, verify new agent boots and participates in turn 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)