### PR TITLE
fix: session recovery resilience and SSE reconnection

### DIFF
--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -123,12 +123,11 @@ export default function SessionPage({
   const isTerminal =
     currentPhase === "finalized" || currentPhase === "cancelled";
   const isOutcomePending = currentPhase === "outcome-pending";
-  // Show Resume only when stuck (not terminal, not outcome-pending, and orchestrator not actively running)
+  // Show Resume when stuck (not terminal, not outcome-pending, and orchestrator not actively running)
   const canResume =
     !isTerminal &&
     !isOutcomePending &&
-    !effectiveRunning &&
-    currentPhase !== "init";
+    !effectiveRunning;
 
   return (
     <main className="mx-auto px-6 py-8 space-y-6">

--- a/src/components/outcome-editor.tsx
+++ b/src/components/outcome-editor.tsx
@@ -156,9 +156,12 @@ export function OutcomeEditor({ sessionId, onAdvance }: Props) {
       .catch(() => {});
   }, [sessionId]);
 
+  const loadedRef = useRef(false);
+  useEffect(() => { loadedRef.current = loaded; }, [loaded]);
+
   useEffect(() => {
     const handleBeforeUnload = () => {
-      if (!dirtyRef.current) return;
+      if (!loadedRef.current || !dirtyRef.current) return;
       const { kind: k, decision: d, notes: n } = latestFieldsRef.current;
       const content = serializeOutcome(turn, k, d, n, reviewBlock);
       navigator.sendBeacon(

--- a/src/hooks/use-sse.ts
+++ b/src/hooks/use-sse.ts
@@ -11,22 +11,39 @@ export function useSSE(sessionId: string | null) {
   useEffect(() => {
     if (!sessionId) return;
 
-    const es = new EventSource(`/api/sessions/${sessionId}/events`);
-    esRef.current = es;
+    let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
 
-    es.onopen = () => setConnected(true);
-    es.onerror = () => setConnected(false);
-    es.onmessage = (e) => {
-      try {
-        const event = JSON.parse(e.data) as SessionEvent;
-        setEvents((prev) => [...prev.slice(-200), event]);
-      } catch {
-        /* ignore parse errors */
-      }
-    };
+    function connect() {
+      if (cancelled) return;
+      const es = new EventSource(`/api/sessions/${sessionId}/events`);
+      esRef.current = es;
+
+      es.onopen = () => setConnected(true);
+      es.onerror = () => {
+        setConnected(false);
+        es.close();
+        esRef.current = null;
+        if (!cancelled) {
+          retryTimer = setTimeout(connect, 3000);
+        }
+      };
+      es.onmessage = (e) => {
+        try {
+          const event = JSON.parse(e.data) as SessionEvent;
+          setEvents((prev) => [...prev.slice(-200), event]);
+        } catch {
+          /* ignore parse errors */
+        }
+      };
+    }
+
+    connect();
 
     return () => {
-      es.close();
+      cancelled = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      esRef.current?.close();
       esRef.current = null;
       setConnected(false);
     };

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -341,11 +341,13 @@ function writeTask(
   );
   fs.mkdirSync(path.dirname(taskPath), { recursive: true });
   fs.writeFileSync(taskPath, text);
-  gitOps.commit(
-    participant.worktreePath,
-    `task: ${phaseLabel}: ${participant.name}`,
-    [".brainstorm/task.md"],
-  );
+  if (gitOps.hasDirtyState(participant.worktreePath)) {
+    gitOps.commit(
+      participant.worktreePath,
+      `task: ${phaseLabel}: ${participant.name}`,
+      [".brainstorm/task.md"],
+    );
+  }
 }
 
 async function runBoot(
@@ -434,9 +436,11 @@ function deliverRound1Pool(
       "round-1-pool.md",
     );
     fs.writeFileSync(poolPath, pool);
-    gitOps.commit(p.worktreePath, `pool delivered: ${p.name}`, [
-      ".brainstorm/round-1-pool.md",
-    ]);
+    if (gitOps.hasDirtyState(p.worktreePath)) {
+      gitOps.commit(p.worktreePath, `pool delivered: ${p.name}`, [
+        ".brainstorm/round-1-pool.md",
+      ]);
+    }
   }
 }
 
@@ -524,11 +528,13 @@ function dropTaskMdFromParticipants(session: Session): void {
     const taskMd = path.join(p.worktreePath, ".brainstorm", "task.md");
     if (!fs.existsSync(taskMd)) continue;
     fs.unlinkSync(taskMd);
-    gitOps.commit(
-      p.worktreePath,
-      `drop task.md before finalize: ${p.name}`,
-      [".brainstorm/task.md"],
-    );
+    if (gitOps.hasDirtyState(p.worktreePath)) {
+      gitOps.commit(
+        p.worktreePath,
+        `drop task.md before finalize: ${p.name}`,
+        [".brainstorm/task.md"],
+      );
+    }
   }
 }
 
@@ -576,9 +582,11 @@ function deliverOutcomeToParticipants(session: Session): void {
     );
     fs.mkdirSync(path.dirname(outcomeDst), { recursive: true });
     fs.writeFileSync(outcomeDst, content);
-    gitOps.commit(p.worktreePath, `outcome delivered: ${p.name}`, [
-      `turn-${session.currentTurn}/outcome.md`,
-    ]);
+    if (gitOps.hasDirtyState(p.worktreePath)) {
+      gitOps.commit(p.worktreePath, `outcome delivered: ${p.name}`, [
+        `turn-${session.currentTurn}/outcome.md`,
+      ]);
+    }
   }
 }
 
@@ -869,28 +877,11 @@ export async function resumeSession(
     return session;
   }
 
-  // From init or boot-done: round-1 commits may already exist, check and skip
+  // From init or boot-done: re-run round-1 (idempotent writes + wake all participants)
   if (phase === PHASE_INIT || phase === PHASE_BOOT_DONE) {
-    const allRound1Done = session.participants.every((p) =>
-      gitOps.hasSubject(
-        session.repoPath,
-        p.branch,
-        prompts.round1Subject(p.name, session.currentTurn),
-      ),
-    );
-    if (allRound1Done) {
-      session.currentPhase = PHASE_ROUND_1_DONE;
-      session.saveManifest();
-    } else {
-      // Wait for remaining round-1 commits
-      const branchToSubject: Record<string, string> = {};
-      for (const p of session.participants) {
-        branchToSubject[p.branch] = prompts.round1Subject(p.name, session.currentTurn);
-      }
-      await gitOps.waitForSubjects(session.repoPath, branchToSubject, 2.0, null, signal);
-      session.currentPhase = PHASE_ROUND_1_DONE;
-      session.saveManifest();
-    }
+    await runRound1(session, null, signal);
+    session.currentPhase = PHASE_ROUND_1_DONE;
+    session.saveManifest();
   }
 
   // From round-1-done: deliver pool + run round-2


### PR DESCRIPTION
## Summary

- **Idempotent orchestrator commits**: `writeTask`, `deliverRound1Pool`, `deliverOutcomeToParticipants`, and `dropTaskMd` now skip `git commit` when the worktree is already clean — prevents crashes when retrying interrupted sessions
- **Robust `resumeSession`**: re-runs `runRound1` (idempotent writes + wakeFor) instead of only waiting for commits that may never arrive; Resume button now available in `init` phase
- **Outcome editor truncation fix**: `beforeunload` save guarded by `loaded` state — prevents empty content overwriting disk when refresh happens before async load completes
- **SSE auto-reconnect**: EventSource reconnects after 3 seconds on error, surviving dev-server restarts and network blips

## Test plan

- [ ] Start a session, kill a participant's tmux pane mid-round, then Resume — verify session recovers and completes
- [ ] Edit outcome, refresh page rapidly before content loads — verify outcome.md is not truncated
- [ ] Restart dev server while viewing a session — verify SSE reconnects and phase updates resume
- [ ] Normal session flow (create → round 1 → round 2 → outcome → advance) still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)